### PR TITLE
feature/S4-75: Add API authentication on endpoints used by external APIs/services.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# Description
+
+Please explain briefly the changes you made here.
+
+## Coding Standards
+
+Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide
+
+## Checklist
+
+- [ ] 3 Amigos
+- [ ] Acceptance Criteria met
+- [ ] Branch named {feature|hotfix|task}/{S4-*}
+- [ ] Commit messages are meaningful
+- [ ] Manually tested
+- [ ] All unit tests passing
+- [ ] API (Karate) tests passing
+- [ ] Pulled latest master into feature branch
+- [ ] Code reviewed
+- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
+- [ ] If your pull request depends on any other, please link them in the description

--- a/src/main/java/uk/gov/companieshouse/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/config/SecurityConfig.java
@@ -4,18 +4,27 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.TokenPermissionsInterceptor;
 import uk.gov.companieshouse.interceptor.DissolutionTokenPermissionsInterceptor;
 
 @Configuration
 public class SecurityConfig implements WebMvcConfigurer {
 
-    private static final String URI_PATTERN = "/dissolution-request/*";
+    private static final String URI_PATTERN = "/dissolution-request/**";
 
-    private static final String[] TOKEN_PERMISSION_AUTH_WHITELIST = {
+    private static final String PAYMENT_ENDPOINT = "/dissolution-request/{company-number}/payment";
+    private static final String SUBMIT_ENDPOINT = "/dissolution-request/submit";
+
+    private static final String[] TOKEN_PERMISSION_AUTH_EXCLUDE_LIST = {
             "/dissolution-request/healthcheck",
-            "/dissolution-request/{company-number}/payment",
-            "/dissolution-request/submit"
+            PAYMENT_ENDPOINT,
+            SUBMIT_ENDPOINT
+    };
+
+    private static final String[] API_KEY_PERMISSION_AUTH_INCLUDE_LIST = {
+            PAYMENT_ENDPOINT,
+            SUBMIT_ENDPOINT
     };
 
     @Autowired
@@ -24,10 +33,13 @@ public class SecurityConfig implements WebMvcConfigurer {
     @Autowired
     private DissolutionTokenPermissionsInterceptor dissolutionTokenPermissionsInterceptor;
 
+    @Autowired
+    private InternalUserInterceptor apiKeyPermissionsInterceptor;
+
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
-        registry.addInterceptor(tokenPermissionsInterceptor).addPathPatterns(URI_PATTERN).excludePathPatterns(TOKEN_PERMISSION_AUTH_WHITELIST);
-        registry.addInterceptor(dissolutionTokenPermissionsInterceptor).addPathPatterns(URI_PATTERN).excludePathPatterns(TOKEN_PERMISSION_AUTH_WHITELIST);
+        registry.addInterceptor(tokenPermissionsInterceptor).addPathPatterns(URI_PATTERN).excludePathPatterns(TOKEN_PERMISSION_AUTH_EXCLUDE_LIST);
+        registry.addInterceptor(dissolutionTokenPermissionsInterceptor).addPathPatterns(URI_PATTERN).excludePathPatterns(TOKEN_PERMISSION_AUTH_EXCLUDE_LIST);
+        registry.addInterceptor(apiKeyPermissionsInterceptor).addPathPatterns(API_KEY_PERMISSION_AUTH_INCLUDE_LIST);
     }
-
 }

--- a/src/test/java/uk/gov/companieshouse/controller/DissolutionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/DissolutionControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.companieshouse.api.util.security.EricConstants;
 import uk.gov.companieshouse.api.util.security.Permission;
 import uk.gov.companieshouse.client.CompanyProfileClient;
 import uk.gov.companieshouse.model.dto.companyProfile.CompanyProfile;
@@ -30,11 +31,18 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.companieshouse.fixtures.CompanyProfileFixtures.generateCompanyProfile;
-import static uk.gov.companieshouse.fixtures.DissolutionFixtures.*;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDirectorRequest;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolutionCreateRequest;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolutionCreateResponse;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolutionGetResponse;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolutionPatchRequest;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolutionPatchResponse;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(DissolutionController.class)
@@ -42,9 +50,7 @@ public class DissolutionControllerTest {
 
     private static final String DISSOLUTION_URI = "/dissolution-request/{company-number}";
 
-    private static final String IDENTITY_HEADER = "ERIC-identity";
     private static final String AUTHORISED_USER_HEADER = "ERIC-Authorised-User";
-    private static final String TOKEN_PERMISSIONS_HEADER = "ERIC-Authorised-Token-Permissions";
 
     private static final String COMPANY_NUMBER = "12345678";
     private static final String COMPANY_NAME = "ComComp";
@@ -69,7 +75,7 @@ public class DissolutionControllerTest {
     @Test
     public void submitDissolutionRequest_returnsUnauthorised_ifNoTokenPermissionsAreProvided() throws Exception {
         final HttpHeaders headers = new HttpHeaders();
-        headers.add(IDENTITY_HEADER, USER_ID);
+        headers.add(EricConstants.ERIC_IDENTITY, USER_ID);
         headers.add(AUTHORISED_USER_HEADER, EMAIL);
 
         mockMvc
@@ -85,9 +91,9 @@ public class DissolutionControllerTest {
     @Test
     public void submitDissolutionRequest_returnsUnauthorised_ifCompanyNumberTokenPermissionDoesNotMatchUri() throws Exception {
         final HttpHeaders headers = new HttpHeaders();
-        headers.add(IDENTITY_HEADER, USER_ID);
+        headers.add(EricConstants.ERIC_IDENTITY, USER_ID);
         headers.add(AUTHORISED_USER_HEADER, EMAIL);
-        headers.add(TOKEN_PERMISSIONS_HEADER, String.format(
+        headers.add(EricConstants.ERIC_AUTHORISED_TOKEN_PERMISSIONS, String.format(
                 "%s=%s %s=%s",
                 Permission.Key.COMPANY_NUMBER.toString(), "1234",
                 Permission.Key.COMPANY_TRANSACTIONS, Permission.Value.UPDATE
@@ -282,7 +288,7 @@ public class DissolutionControllerTest {
     @Test
     public void getDissolutionRequest_returnsUnauthorised_ifNoTokenPermissionsAreProvided() throws Exception {
         final HttpHeaders headers = new HttpHeaders();
-        headers.add(IDENTITY_HEADER, USER_ID);
+        headers.add(EricConstants.ERIC_IDENTITY, USER_ID);
         headers.add(AUTHORISED_USER_HEADER, EMAIL);
 
         mockMvc
@@ -296,9 +302,9 @@ public class DissolutionControllerTest {
     @Test
     public void getDissolutionRequest_returnsUnauthorised_ifCompanyNumberTokenPermissionDoesNotMatchUri() throws Exception {
         final HttpHeaders headers = new HttpHeaders();
-        headers.add(IDENTITY_HEADER, USER_ID);
+        headers.add(EricConstants.ERIC_IDENTITY, USER_ID);
         headers.add(AUTHORISED_USER_HEADER, EMAIL);
-        headers.add(TOKEN_PERMISSIONS_HEADER, String.format(
+        headers.add(EricConstants.ERIC_AUTHORISED_TOKEN_PERMISSIONS, String.format(
                 "%s=%s %s=%s",
                 Permission.Key.COMPANY_NUMBER.toString(), "1234",
                 Permission.Key.COMPANY_TRANSACTIONS, Permission.Value.UPDATE
@@ -342,7 +348,7 @@ public class DissolutionControllerTest {
     @Test
     public void patchDissolutionRequest_returnsUnauthorised_ifNoTokenPermissionsAreProvided() throws Exception {
         final HttpHeaders headers = new HttpHeaders();
-        headers.add(IDENTITY_HEADER, USER_ID);
+        headers.add(EricConstants.ERIC_IDENTITY, USER_ID);
         headers.add(AUTHORISED_USER_HEADER, EMAIL);
 
         mockMvc
@@ -358,9 +364,9 @@ public class DissolutionControllerTest {
     @Test
     public void patchDissolutionRequest_returnsUnauthorised_ifCompanyNumberTokenPermissionDoesNotMatchUri() throws Exception {
         final HttpHeaders headers = new HttpHeaders();
-        headers.add(IDENTITY_HEADER, USER_ID);
+        headers.add(EricConstants.ERIC_IDENTITY, USER_ID);
         headers.add(AUTHORISED_USER_HEADER, EMAIL);
-        headers.add(TOKEN_PERMISSIONS_HEADER, String.format(
+        headers.add(EricConstants.ERIC_AUTHORISED_TOKEN_PERMISSIONS, String.format(
                 "%s=%s %s=%s",
                 Permission.Key.COMPANY_NUMBER.toString(), "1234",
                 Permission.Key.COMPANY_TRANSACTIONS, Permission.Value.UPDATE
@@ -451,9 +457,9 @@ public class DissolutionControllerTest {
 
     private HttpHeaders createHttpHeaders() {
         final HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.add(IDENTITY_HEADER, USER_ID);
+        httpHeaders.add(EricConstants.ERIC_IDENTITY, USER_ID);
         httpHeaders.add(AUTHORISED_USER_HEADER, EMAIL);
-        httpHeaders.add(TOKEN_PERMISSIONS_HEADER, String.format(
+        httpHeaders.add(EricConstants.ERIC_AUTHORISED_TOKEN_PERMISSIONS, String.format(
                 "%s=%s %s=%s",
                 Permission.Key.COMPANY_NUMBER.toString(), COMPANY_NUMBER,
                 Permission.Key.COMPANY_STATUS, Permission.Value.UPDATE

--- a/src/test/java/uk/gov/companieshouse/controller/SubmitControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/SubmitControllerTest.java
@@ -5,11 +5,16 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.companieshouse.api.util.security.EricConstants;
+import uk.gov.companieshouse.api.util.security.SecurityConstants;
 import uk.gov.companieshouse.service.dissolution.chips.DissolutionChipsService;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -19,6 +24,8 @@ public class SubmitControllerTest {
 
     private static final String SUBMIT_URI = "/dissolution-request/submit";
 
+    private static final String IDENTITY_HEADER_VALUE = "identity";
+
     @MockBean
     private DissolutionChipsService service;
 
@@ -26,11 +33,53 @@ public class SubmitControllerTest {
     private MockMvc mockMvc;
 
     @Test
+    public void submitDissolutionsToChips_returnsUnauthorised_ifEricIdentityIsNotProvided() throws Exception {
+        HttpHeaders headers = createHttpHeaders();
+        headers.remove(EricConstants.ERIC_IDENTITY);
+
+        mockMvc
+                .perform(
+                        post(SUBMIT_URI)
+                                .headers(headers)
+                )
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void submitDissolutionsToChips_returnsForbidden_ifEricIdentityTypeIsNotCorrect() throws Exception {
+        HttpHeaders headers = createHttpHeaders();
+        headers.set(EricConstants.ERIC_IDENTITY_TYPE, "some-incorrect-identity-type");
+
+        mockMvc
+                .perform(
+                        post(SUBMIT_URI)
+                                .headers(headers)
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void submitDissolutionsToChips_returnsForbidden_ifEricAuthorisedKeyRolesIsNotCorrect() throws Exception {
+        HttpHeaders headers = createHttpHeaders();
+        headers.set(EricConstants.ERIC_AUTHORISED_KEY_ROLES, "some-incorrect-authorised-key-roles-value");
+
+        mockMvc
+                .perform(
+                        post(SUBMIT_URI)
+                                .headers(headers)
+                )
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     public void submitDissolutionsToChips_returnsServiceUnavailable_ifChipsIsNotAvailable() throws Exception {
         when(service.isAvailable()).thenReturn(false);
 
         mockMvc
-                .perform(post(SUBMIT_URI))
+                .perform(
+                        post(SUBMIT_URI)
+                                .headers(createHttpHeaders())
+                )
                 .andExpect(status().isServiceUnavailable());
 
         verify(service, never()).submitDissolutionsToChips();
@@ -41,9 +90,22 @@ public class SubmitControllerTest {
         when(service.isAvailable()).thenReturn(true);
 
         mockMvc
-                .perform(post(SUBMIT_URI))
+                .perform(
+                        post(SUBMIT_URI)
+                                .headers(createHttpHeaders())
+                )
                 .andExpect(status().isOk());
 
         verify(service).submitDissolutionsToChips();
+    }
+
+    private HttpHeaders createHttpHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add(EricConstants.ERIC_IDENTITY, IDENTITY_HEADER_VALUE);
+        headers.add(EricConstants.ERIC_IDENTITY_TYPE, SecurityConstants.API_KEY_IDENTITY_TYPE);
+        headers.add(EricConstants.ERIC_AUTHORISED_KEY_ROLES, SecurityConstants.INTERNAL_USER_ROLE);
+
+        return headers;
     }
 }


### PR DESCRIPTION
- Add API authentication on endpoints used by external APIs/services.
- Add pull request template.

Relates to https://github.com/companieshouse/taf-api-karate/pull/190.