### PR TITLE
hotfix/S4-101 - Dissolution Certificate CHIPS Submission

### DIFF
--- a/src/main/java/uk/gov/companieshouse/mapper/chips/DissolutionChipsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/chips/DissolutionChipsMapper.java
@@ -25,7 +25,7 @@ public class DissolutionChipsMapper {
         this.formDataMapper = formDataMapper;
     }
 
-    public DissolutionChipsRequest mapToDissolutionChipsRequest(Dissolution dissolution, String certificate) {
+    public DissolutionChipsRequest mapToDissolutionChipsRequest(Dissolution dissolution, byte[] certificate) {
         final DissolutionChipsRequest request = new DissolutionChipsRequest();
 
         request.setPackageMetadata(mapToPackageMetadata(dissolution));
@@ -43,17 +43,17 @@ public class DissolutionChipsMapper {
         return metadata;
     }
 
-    private ChipsForm mapToChipsForm(Dissolution dissolution, String certificate) {
+    private ChipsForm mapToChipsForm(Dissolution dissolution, byte[] certificate) {
         final ChipsForm form = new ChipsForm();
 
         form.setBarcode(dissolution.getData().getApplication().getBarcode());
-        form.setXml(encode(formDataMapper.mapToChipsFormDataXml(dissolution)));
+        form.setXml(encode(formDataMapper.mapToChipsFormDataXml(dissolution).getBytes()));
         form.setAttachments(Collections.singletonList(mapToChipsFormAttachment(certificate)));
 
         return form;
     }
 
-    private ChipsFormAttachment mapToChipsFormAttachment(String certificate) {
+    private ChipsFormAttachment mapToChipsFormAttachment(byte[] certificate) {
         final ChipsFormAttachment attachment = new ChipsFormAttachment();
 
         attachment.setCategory(FORM_CATEGORY);
@@ -63,7 +63,7 @@ public class DissolutionChipsMapper {
         return attachment;
     }
 
-    private String encode(String input) {
-        return Base64.getEncoder().encodeToString(input.getBytes());
+    private String encode(byte[] input) {
+        return Base64.getEncoder().encodeToString(input);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/certificate/DissolutionCertificateDownloader.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/certificate/DissolutionCertificateDownloader.java
@@ -5,8 +5,6 @@ import uk.gov.companieshouse.model.db.dissolution.Dissolution;
 import uk.gov.companieshouse.model.db.dissolution.DissolutionCertificate;
 import uk.gov.companieshouse.service.aws.S3Service;
 
-import java.nio.charset.StandardCharsets;
-
 @Service
 public class DissolutionCertificateDownloader {
 
@@ -16,11 +14,9 @@ public class DissolutionCertificateDownloader {
         this.s3 = s3;
     }
 
-    public String downloadDissolutionCertificate(Dissolution dissolution) {
+    public byte[] downloadDissolutionCertificate(Dissolution dissolution) {
         final DissolutionCertificate certificate = dissolution.getCertificate();
 
-        final byte[] certificateContents = s3.downloadFile(certificate.getBucket(), certificate.getKey());
-
-        return new String(certificateContents, StandardCharsets.UTF_8);
+        return s3.downloadFile(certificate.getBucket(), certificate.getKey());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/chips/ChipsSubmitter.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/chips/ChipsSubmitter.java
@@ -51,7 +51,7 @@ public class ChipsSubmitter {
 
         logger.info("Sending dissolution request to CHIPS for company {}", companyNumber);
 
-        final String certificateContents = certificateDownloader.downloadDissolutionCertificate(dissolution);
+        final byte[] certificateContents = certificateDownloader.downloadDissolutionCertificate(dissolution);
 
         try {
             final DissolutionChipsRequest dissolutionRequest = mapper.mapToDissolutionChipsRequest(dissolution, certificateContents);

--- a/src/test/java/uk/gov/companieshouse/mapper/chips/DissolutionChipsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/chips/DissolutionChipsMapperTest.java
@@ -22,7 +22,7 @@ public class DissolutionChipsMapperTest {
     private static final String DISSOLUTION_REFERENCE = "someRef";
     private static final String DISSOLUTION_BARCODE = "B4RC0D3";
 
-    private static final String CERTIFICATE_CONTENTS = "some certificate contents";
+    private static final byte[] CERTIFICATE_CONTENTS = "some certificate contents".getBytes();
 
     @InjectMocks
     private DissolutionChipsMapper mapper;
@@ -69,7 +69,7 @@ public class DissolutionChipsMapperTest {
         assertEquals(1, request.getForms().get(0).getAttachments().size());
         assertEquals("application/pdf", request.getForms().get(0).getAttachments().get(0).getMimeType());
         assertEquals("FORM IMAGE PDF", request.getForms().get(0).getAttachments().get(0).getCategory());
-        assertEquals(CERTIFICATE_CONTENTS, decode(request.getForms().get(0).getAttachments().get(0).getData()));
+        assertEquals(new String(CERTIFICATE_CONTENTS), decode(request.getForms().get(0).getAttachments().get(0).getData()));
     }
 
     private String decode(String encoded) {

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/certificate/DissolutionCertificateDownloaderTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/certificate/DissolutionCertificateDownloaderTest.java
@@ -1,0 +1,47 @@
+package uk.gov.companieshouse.service.dissolution.certificate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.model.db.dissolution.Dissolution;
+import uk.gov.companieshouse.model.db.dissolution.DissolutionCertificate;
+import uk.gov.companieshouse.service.aws.S3Service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolution;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolutionCertificate;
+
+@ExtendWith(MockitoExtension.class)
+public class DissolutionCertificateDownloaderTest {
+
+    @InjectMocks
+    private DissolutionCertificateDownloader downloader;
+
+    @Mock
+    private S3Service s3;
+
+    @Test
+    public void downloadDissolutionCertificate_downloadsFromS3UsingDissolutionCertificateKeyAndBucket() {
+        final byte[] certificateContents = "some certificate".getBytes();
+
+        final Dissolution dissolution = generateDissolution();
+
+        final DissolutionCertificate certificate = generateDissolutionCertificate();
+        certificate.setBucket("some-cert-bucket");
+        certificate.setKey("some-cert-key.pdf");
+
+        dissolution.setCertificate(certificate);
+
+        when(s3.downloadFile("some-cert-bucket", "some-cert-key.pdf")).thenReturn(certificateContents);
+
+        final byte[] result = downloader.downloadDissolutionCertificate(dissolution);
+
+        assertEquals(certificateContents, result);
+
+        verify(s3).downloadFile("some-cert-bucket", "some-cert-key.pdf");
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/chips/ChipsSubmitterTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/chips/ChipsSubmitterTest.java
@@ -28,6 +28,8 @@ import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolu
 @ExtendWith(MockitoExtension.class)
 public class ChipsSubmitterTest {
 
+    private static final byte[] CERTIFICATE_CONTENTS = "some certificate contents".getBytes();
+
     @InjectMocks
     private ChipsSubmitter submitter;
 
@@ -64,13 +66,13 @@ public class ChipsSubmitterTest {
     public void submitDissolutionToChips_downloadsCertificate_mapsToRequest_sendsToChips() {
         final DissolutionChipsRequest request = generateDissolutionChipsRequest();
 
-        when(certificateDownloader.downloadDissolutionCertificate(dissolution)).thenReturn("some certificate contents");
-        when(mapper.mapToDissolutionChipsRequest(dissolution, "some certificate contents")).thenReturn(request);
+        when(certificateDownloader.downloadDissolutionCertificate(dissolution)).thenReturn(CERTIFICATE_CONTENTS);
+        when(mapper.mapToDissolutionChipsRequest(dissolution, CERTIFICATE_CONTENTS)).thenReturn(request);
 
         submitter.submitDissolutionToChips(dissolution);
 
         verify(certificateDownloader).downloadDissolutionCertificate(dissolution);
-        verify(mapper).mapToDissolutionChipsRequest(dissolution, "some certificate contents");
+        verify(mapper).mapToDissolutionChipsRequest(dissolution, CERTIFICATE_CONTENTS);
         verify(client).sendDissolutionToChips(request);
     }
 
@@ -78,8 +80,8 @@ public class ChipsSubmitterTest {
     public void submitDissolutionToChips_updatesDatabase_ifChipsSubmissionSucceeds() {
         final DissolutionChipsRequest request = generateDissolutionChipsRequest();
 
-        when(certificateDownloader.downloadDissolutionCertificate(dissolution)).thenReturn("some certificate contents");
-        when(mapper.mapToDissolutionChipsRequest(dissolution, "some certificate contents")).thenReturn(request);
+        when(certificateDownloader.downloadDissolutionCertificate(dissolution)).thenReturn(CERTIFICATE_CONTENTS);
+        when(mapper.mapToDissolutionChipsRequest(dissolution, CERTIFICATE_CONTENTS)).thenReturn(request);
 
         submitter.submitDissolutionToChips(dissolution);
 
@@ -97,8 +99,8 @@ public class ChipsSubmitterTest {
 
         final DissolutionChipsRequest request = generateDissolutionChipsRequest();
 
-        when(certificateDownloader.downloadDissolutionCertificate(dissolution)).thenReturn("some certificate contents");
-        when(mapper.mapToDissolutionChipsRequest(dissolution, "some certificate contents")).thenReturn(request);
+        when(certificateDownloader.downloadDissolutionCertificate(dissolution)).thenReturn(CERTIFICATE_CONTENTS);
+        when(mapper.mapToDissolutionChipsRequest(dissolution, CERTIFICATE_CONTENTS)).thenReturn(request);
         doThrow(new ChipsNotAvailableException()).when(client).sendDissolutionToChips(request);
         when(config.getChipsRetryLimit()).thenReturn(10);
 
@@ -119,8 +121,8 @@ public class ChipsSubmitterTest {
 
         final DissolutionChipsRequest request = generateDissolutionChipsRequest();
 
-        when(certificateDownloader.downloadDissolutionCertificate(dissolution)).thenReturn("some certificate contents");
-        when(mapper.mapToDissolutionChipsRequest(dissolution, "some certificate contents")).thenReturn(request);
+        when(certificateDownloader.downloadDissolutionCertificate(dissolution)).thenReturn(CERTIFICATE_CONTENTS);
+        when(mapper.mapToDissolutionChipsRequest(dissolution, CERTIFICATE_CONTENTS)).thenReturn(request);
         doThrow(new ChipsNotAvailableException()).when(client).sendDissolutionToChips(request);
         when(config.getChipsRetryLimit()).thenReturn(10);
 


### PR DESCRIPTION
# Description

Coverting to UTF8 was changing to contents of the PDF, causing it to render blank in chips. Now going from byte[] -> base 64 string

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [ ] Branch named {feature|hotfix|task}/{S4-*}
- [ ] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [x] API (Karate) tests passing
- [x] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description