### PR TITLE
feature/S4-95 - Email Signatories to Sign

### DIFF
--- a/src/main/java/uk/gov/companieshouse/mapper/email/DissolutionEmailMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/email/DissolutionEmailMapper.java
@@ -3,8 +3,11 @@ package uk.gov.companieshouse.mapper.email;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.config.EnvironmentConfig;
 import uk.gov.companieshouse.model.db.dissolution.Dissolution;
+import uk.gov.companieshouse.model.db.dissolution.DissolutionDirector;
+import uk.gov.companieshouse.model.dto.email.SignatoryToSignEmailData;
 import uk.gov.companieshouse.model.dto.email.SuccessfulPaymentEmailData;
 
+import static uk.gov.companieshouse.model.Constants.SIGNATORY_TO_SIGN_EMAIL_SUBJECT;
 import static uk.gov.companieshouse.model.Constants.SUCCESSFUL_PAYMENT_EMAIL_SUBJECT;
 
 @Service
@@ -33,5 +36,20 @@ public class DissolutionEmailMapper {
         successfulPaymentEmailData.setCdnHost(environmentConfig.getCdnHost());
 
         return successfulPaymentEmailData;
+    }
+
+    public SignatoryToSignEmailData mapToSignatoryToSignEmailData(Dissolution dissolution, String signatoryEmail, String deadline) {
+        SignatoryToSignEmailData emailData = new SignatoryToSignEmailData();
+
+        emailData.setTo(signatoryEmail);
+        emailData.setSubject(SIGNATORY_TO_SIGN_EMAIL_SUBJECT);
+        emailData.setDissolutionReferenceNumber(dissolution.getData().getApplication().getReference());
+        emailData.setCompanyNumber(dissolution.getCompany().getNumber());
+        emailData.setCompanyName(dissolution.getCompany().getName());
+        emailData.setDissolutionDeadlineDate(deadline);
+        emailData.setChsUrl(environmentConfig.getChsUrl());
+        emailData.setCdnHost(environmentConfig.getCdnHost());
+
+        return emailData;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/mapper/email/EmailMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/email/EmailMapper.java
@@ -13,9 +13,9 @@ import static uk.gov.companieshouse.model.Constants.EMAIL_APP_ID;
 import static uk.gov.companieshouse.model.Constants.EMAIL_TOPIC;
 
 @Service
-public class EmailMapper<T> {
+public class EmailMapper {
 
-    public EmailDocument<T> mapToEmailDocument(T emailData, String emailAddress, String messageType) {
+    public <T> EmailDocument<T> mapToEmailDocument(T emailData, String emailAddress, String messageType) {
         EmailDocument<T> emailDocument = new EmailDocument<>();
 
         emailDocument.setAppId(EMAIL_APP_ID);

--- a/src/main/java/uk/gov/companieshouse/model/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/model/Constants.java
@@ -24,6 +24,8 @@ public final class Constants {
    public static final String EMAIL_TOPIC = "email-send";
    public static final String SUCCESSFUL_PAYMENT_EMAIL_SUBJECT = "Your application has been submitted";
    public static final String SUCCESSFUL_PAYMENT_MESSAGE_TYPE = "dissolution-payment-confirmation";
+   public static final String SIGNATORY_TO_SIGN_EMAIL_SUBJECT = "You need to sign the application to strike off and dissolve a company";
+   public static final String SIGNATORY_TO_SIGN_MESSAGE_TYPE = "dissolution-signatory-to-sign";
 
    /* Headers */
    public static final String HEADER_AUTHORIZATION = "Authorization";

--- a/src/main/java/uk/gov/companieshouse/model/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/model/Constants.java
@@ -25,7 +25,7 @@ public final class Constants {
    public static final String SUCCESSFUL_PAYMENT_EMAIL_SUBJECT = "Your application has been submitted";
    public static final String SUCCESSFUL_PAYMENT_MESSAGE_TYPE = "dissolution-payment-confirmation";
    public static final String SIGNATORY_TO_SIGN_EMAIL_SUBJECT = "You need to sign the application to strike off and dissolve a company";
-   public static final String SIGNATORY_TO_SIGN_MESSAGE_TYPE = "dissolution-signatory-to-sign";
+   public static final String SIGNATORY_TO_SIGN_MESSAGE_TYPE = "dissolution_signatory_to_sign";
 
    /* Headers */
    public static final String HEADER_AUTHORIZATION = "Authorization";

--- a/src/main/java/uk/gov/companieshouse/model/dto/email/SignatoryToSignEmailData.java
+++ b/src/main/java/uk/gov/companieshouse/model/dto/email/SignatoryToSignEmailData.java
@@ -1,0 +1,68 @@
+package uk.gov.companieshouse.model.dto.email;
+
+public class SignatoryToSignEmailData extends EmailData {
+
+    private String to;
+    private String subject;
+    private String dissolutionReferenceNumber;
+    private String companyNumber;
+    private String companyName;
+    private String chsUrl;
+    private String dissolutionDeadlineDate;
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getDissolutionReferenceNumber() {
+        return dissolutionReferenceNumber;
+    }
+
+    public void setDissolutionReferenceNumber(String dissolutionReferenceNumber) {
+        this.dissolutionReferenceNumber = dissolutionReferenceNumber;
+    }
+
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+
+    public void setCompanyNumber(String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public String getChsUrl() {
+        return chsUrl;
+    }
+
+    public void setChsUrl(String chsUrl) {
+        this.chsUrl = chsUrl;
+    }
+
+    public String getDissolutionDeadlineDate() {
+        return dissolutionDeadlineDate;
+    }
+
+    public void setDissolutionDeadlineDate(String dissolutionDeadlineDate) {
+        this.dissolutionDeadlineDate = dissolutionDeadlineDate;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionCreator.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionCreator.java
@@ -22,6 +22,7 @@ public class DissolutionCreator {
     private final DissolutionRequestMapper requestMapper;
     private final DissolutionRepository repository;
     private final DissolutionResponseMapper responseMapper;
+    private final DissolutionEmailService emailService;
 
     @Autowired
     public DissolutionCreator(
@@ -29,12 +30,14 @@ public class DissolutionCreator {
         BarcodeGenerator barcodeGenerator,
         DissolutionRequestMapper requestMapper,
         DissolutionRepository repository,
-        DissolutionResponseMapper responseMapper) {
+        DissolutionResponseMapper responseMapper,
+        DissolutionEmailService emailService) {
         this.referenceGenerator = referenceGenerator;
         this.barcodeGenerator = barcodeGenerator;
         this.requestMapper = requestMapper;
         this.repository = repository;
         this.responseMapper = responseMapper;
+        this.emailService = emailService;
     }
 
     public DissolutionCreateResponse create(DissolutionCreateRequest body, CompanyProfile companyProfile, Map<String, CompanyOfficer> directors, String userId, String ip, String email) {
@@ -44,6 +47,8 @@ public class DissolutionCreator {
         final Dissolution dissolution = requestMapper.mapToDissolution(body, companyProfile, directors, userId, email, ip, reference, barcode);
 
         repository.insert(dissolution);
+
+        emailService.notifySignatoriesToSign(dissolution);
 
         return responseMapper.mapToDissolutionCreateResponse(dissolution);
     }

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionDeadlineDateCalculator.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionDeadlineDateCalculator.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.service.dissolution;
+
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+@Service
+public class DissolutionDeadlineDateCalculator {
+
+    private static final String SIGNATORY_TO_SIGN_DATE_FORMAT = "dd MMMM yyyy";
+
+    public String calculateSignatoryDeadlineDate(LocalDateTime start) {
+        return start.plus(2, ChronoUnit.WEEKS).format(DateTimeFormatter.ofPattern(SIGNATORY_TO_SIGN_DATE_FORMAT));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionEmailService.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionEmailService.java
@@ -5,27 +5,40 @@ import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.mapper.email.DissolutionEmailMapper;
 import uk.gov.companieshouse.mapper.email.EmailMapper;
 import uk.gov.companieshouse.model.db.dissolution.Dissolution;
+import uk.gov.companieshouse.model.db.dissolution.DissolutionDirector;
 import uk.gov.companieshouse.model.dto.email.EmailDocument;
+import uk.gov.companieshouse.model.dto.email.SignatoryToSignEmailData;
 import uk.gov.companieshouse.model.dto.email.SuccessfulPaymentEmailData;
 import uk.gov.companieshouse.service.email.EmailService;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static uk.gov.companieshouse.model.Constants.SIGNATORY_TO_SIGN_MESSAGE_TYPE;
 import static uk.gov.companieshouse.model.Constants.SUCCESSFUL_PAYMENT_MESSAGE_TYPE;
 
 @Service
 public class DissolutionEmailService {
 
     private final DissolutionEmailMapper dissolutionEmailMapper;
-    private final EmailMapper<SuccessfulPaymentEmailData> emailMapper;
+    private final EmailMapper emailMapper;
     private final EmailService emailService;
+    private final DissolutionDeadlineDateCalculator deadlineDateCalculator;
 
     @Autowired
     public DissolutionEmailService(
-            DissolutionEmailMapper dissolutionEmailMapper, EmailMapper<SuccessfulPaymentEmailData> emailMapper,
-            EmailService emailService
+            DissolutionEmailMapper dissolutionEmailMapper,
+            EmailMapper emailMapper,
+            EmailService emailService,
+            DissolutionDeadlineDateCalculator deadlineDateCalculator
     ) {
         this.dissolutionEmailMapper = dissolutionEmailMapper;
         this.emailMapper = emailMapper;
         this.emailService = emailService;
+        this.deadlineDateCalculator = deadlineDateCalculator;
     }
 
     public void sendSuccessfulPaymentEmail(Dissolution dissolution) {
@@ -37,5 +50,29 @@ public class DissolutionEmailService {
         );
 
         emailService.sendMessage(emailDocument);
+    }
+
+    public void notifySignatoriesToSign(Dissolution dissolution) {
+        final String deadlineDate = deadlineDateCalculator.calculateSignatoryDeadlineDate(LocalDateTime.now());
+
+        getUniqueSignatories(dissolution)
+                .stream()
+                .map(signatoryEmail -> mapToSignatoryToSignEmail(dissolution, signatoryEmail, deadlineDate))
+                .forEach(emailService::sendMessage);
+    }
+
+    private List<String> getUniqueSignatories(Dissolution dissolution) {
+        return dissolution
+                .getData()
+                .getDirectors()
+                .stream()
+                .map(DissolutionDirector::getEmail)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    private EmailDocument<SignatoryToSignEmailData> mapToSignatoryToSignEmail(Dissolution dissolution, String signatoryEmail, String deadlineDate) {
+        final SignatoryToSignEmailData emailData = dissolutionEmailMapper.mapToSignatoryToSignEmailData(dissolution, signatoryEmail, deadlineDate);
+        return this.emailMapper.mapToEmailDocument(emailData, signatoryEmail, SIGNATORY_TO_SIGN_MESSAGE_TYPE);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/service/email/EmailService.java
+++ b/src/main/java/uk/gov/companieshouse/service/email/EmailService.java
@@ -15,14 +15,14 @@ import java.util.concurrent.ExecutionException;
 @Service
 public class EmailService {
     private final EmailSerialiser emailSerialiser;
-    private final EmailMapper<?> emailMapper;
+    private final EmailMapper emailMapper;
     private final CHKafkaProducer kafkaProducer;
 
     private final Logger logger = LoggerFactory.getLogger(EmailService.class);
 
     @Autowired
     public EmailService(
-            EmailSerialiser emailSerialiser, EmailMapper<?> emailMapper, CHKafkaProducer kafkaProducer
+            EmailSerialiser emailSerialiser, EmailMapper emailMapper, CHKafkaProducer kafkaProducer
     ) {
         this.emailSerialiser = emailSerialiser;
         this.emailMapper = emailMapper;

--- a/src/test/java/uk/gov/companieshouse/fixtures/EmailFixtures.java
+++ b/src/test/java/uk/gov/companieshouse/fixtures/EmailFixtures.java
@@ -2,10 +2,12 @@ package uk.gov.companieshouse.fixtures;
 
 import uk.gov.companieshouse.kafka.message.Message;
 import uk.gov.companieshouse.model.dto.email.EmailDocument;
+import uk.gov.companieshouse.model.dto.email.SignatoryToSignEmailData;
 import uk.gov.companieshouse.model.dto.email.SuccessfulPaymentEmailData;
 
 import static uk.gov.companieshouse.model.Constants.EMAIL_APP_ID;
 import static uk.gov.companieshouse.model.Constants.EMAIL_TOPIC;
+import static uk.gov.companieshouse.model.Constants.SIGNATORY_TO_SIGN_EMAIL_SUBJECT;
 import static uk.gov.companieshouse.model.Constants.SUCCESSFUL_PAYMENT_EMAIL_SUBJECT;
 
 public class EmailFixtures {
@@ -14,7 +16,7 @@ public class EmailFixtures {
     public static final String EMAIL_ADDRESS = "user@email.com";
     public static final String MESSAGE_TYPE = "some-message-type";
 
-    public static final String CDN_URL = "http://chs-url";
+    public static final String CHS_URL = "http://chs-url";
     public static final String CDN_HOST = "http://some-cdn-host";
 
     public static SuccessfulPaymentEmailData generateSuccessfulPaymentEmailData() {
@@ -25,10 +27,25 @@ public class EmailFixtures {
         successfulPaymentEmailData.setDissolutionReferenceNumber("ABC123");
         successfulPaymentEmailData.setCompanyNumber("12345678");
         successfulPaymentEmailData.setCompanyName("Companies House");
-        successfulPaymentEmailData.setChsUrl(CDN_URL);
+        successfulPaymentEmailData.setChsUrl(CHS_URL);
         successfulPaymentEmailData.setCdnHost(CDN_HOST);
 
         return successfulPaymentEmailData;
+    }
+
+    public static SignatoryToSignEmailData generateSignatoryToSignEmailData() {
+        final SignatoryToSignEmailData emailData = new SignatoryToSignEmailData();
+
+        emailData.setTo("user@mail.com");
+        emailData.setSubject(SIGNATORY_TO_SIGN_EMAIL_SUBJECT);
+        emailData.setDissolutionReferenceNumber("ABC123");
+        emailData.setCompanyNumber("12345678");
+        emailData.setCompanyName("Companies House");
+        emailData.setDissolutionDeadlineDate("17 September 2020");
+        emailData.setChsUrl(CHS_URL);
+        emailData.setCdnHost(CDN_HOST);
+
+        return emailData;
     }
 
     public static <T> EmailDocument<T> generateEmailDocument(T data) {

--- a/src/test/java/uk/gov/companieshouse/mapper/email/DissolutionEmailMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/email/DissolutionEmailMapperTest.java
@@ -1,23 +1,31 @@
 package uk.gov.companieshouse.mapper.email;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.config.EnvironmentConfig;
-import uk.gov.companieshouse.fixtures.DissolutionFixtures;
 import uk.gov.companieshouse.fixtures.EmailFixtures;
+import uk.gov.companieshouse.model.db.dissolution.Company;
 import uk.gov.companieshouse.model.db.dissolution.Dissolution;
+import uk.gov.companieshouse.model.dto.email.SignatoryToSignEmailData;
 import uk.gov.companieshouse.model.dto.email.SuccessfulPaymentEmailData;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateCompany;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolution;
 import static uk.gov.companieshouse.fixtures.EmailFixtures.CDN_HOST;
-import static uk.gov.companieshouse.fixtures.EmailFixtures.CDN_URL;
+import static uk.gov.companieshouse.fixtures.EmailFixtures.CHS_URL;
+import static uk.gov.companieshouse.model.Constants.SIGNATORY_TO_SIGN_EMAIL_SUBJECT;
 
 @ExtendWith(MockitoExtension.class)
 public class DissolutionEmailMapperTest {
+
+    private static final String SIGNATORY_TO_SIGN_EMAIL = "signatory@mail.com";
+    private static final String SIGNATORY_TO_SIGN_DEADLINE = "17 September 2020";
 
     @InjectMocks
     private DissolutionEmailMapper dissolutionEmailMapper;
@@ -25,13 +33,16 @@ public class DissolutionEmailMapperTest {
     @Mock
     private EnvironmentConfig environmentConfig;
 
+    @BeforeEach
+    public void setup() {
+        when(environmentConfig.getChsUrl()).thenReturn(CHS_URL);
+        when(environmentConfig.getCdnHost()).thenReturn(CDN_HOST);
+    }
+
     @Test
     public void mapToSuccessfulPaymentEmailData() {
-        final Dissolution dissolution = DissolutionFixtures.generateDissolution();
+        final Dissolution dissolution = generateDissolution();
         final SuccessfulPaymentEmailData successfulPaymentEmailData = EmailFixtures.generateSuccessfulPaymentEmailData();
-
-        when(environmentConfig.getChsUrl()).thenReturn(CDN_URL);
-        when(environmentConfig.getCdnHost()).thenReturn(CDN_HOST);
 
         final SuccessfulPaymentEmailData result = dissolutionEmailMapper.mapToSuccessfulPaymentEmailData(dissolution);
 
@@ -42,5 +53,39 @@ public class DissolutionEmailMapperTest {
         assertEquals(successfulPaymentEmailData.getCompanyName(), result.getCompanyName());
         assertEquals(successfulPaymentEmailData.getChsUrl(), result.getChsUrl());
         assertEquals(successfulPaymentEmailData.getCdnHost(), result.getCdnHost());
+    }
+
+    @Test
+    public void mapToSignatoryToSignEmailData_mapsDissolutionInfo() {
+        final Company company = generateCompany();
+        company.setName("Some Company Name");
+        company.setNumber("12345");
+
+        final Dissolution dissolution = generateDissolution();
+        dissolution.setCompany(company);
+        dissolution.getData().getApplication().setReference("abc123");
+
+        final SignatoryToSignEmailData result = dissolutionEmailMapper.mapToSignatoryToSignEmailData(dissolution, SIGNATORY_TO_SIGN_EMAIL, SIGNATORY_TO_SIGN_DEADLINE);
+
+        assertEquals("Some Company Name", result.getCompanyName());
+        assertEquals("12345", result.getCompanyNumber());
+        assertEquals("abc123", result.getDissolutionReferenceNumber());
+    }
+
+    @Test
+    public void mapToSignatoryToSignEmailData_mapsSignatoryInfo_andDeadline_andSubject() {
+        final SignatoryToSignEmailData result = dissolutionEmailMapper.mapToSignatoryToSignEmailData(generateDissolution(), SIGNATORY_TO_SIGN_EMAIL, SIGNATORY_TO_SIGN_DEADLINE);
+
+        assertEquals(SIGNATORY_TO_SIGN_EMAIL, result.getTo());
+        assertEquals(SIGNATORY_TO_SIGN_DEADLINE, result.getDissolutionDeadlineDate());
+        assertEquals(SIGNATORY_TO_SIGN_EMAIL_SUBJECT, result.getSubject());
+    }
+
+    @Test
+    public void mapToSignatoryToSignEmailData_mapsEnvironmentInfo() {
+        final SignatoryToSignEmailData result = dissolutionEmailMapper.mapToSignatoryToSignEmailData(generateDissolution(), SIGNATORY_TO_SIGN_EMAIL, SIGNATORY_TO_SIGN_DEADLINE);
+
+        assertEquals(CHS_URL, result.getChsUrl());
+        assertEquals(CDN_HOST, result.getCdnHost());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/mapper/email/EmailMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/email/EmailMapperTest.java
@@ -16,7 +16,7 @@ public class EmailMapperTest {
 
     private static EmailDocument<?> emailDocument;
 
-    private final EmailMapper<Object> emailMapper = new EmailMapper<>();
+    private final EmailMapper emailMapper = new EmailMapper();
 
     @BeforeAll
     public static void setUp() {

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionCreatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionCreatorTest.java
@@ -47,6 +47,9 @@ public class DissolutionCreatorTest {
     @Mock
     private DissolutionResponseMapper responseMapper;
 
+    @Mock
+    private DissolutionEmailService emailService;
+
     public static final String COMPANY_NUMBER = "12345678";
     public static final String USER_ID = "123";
     public static final String IP = "192.168.0.1";
@@ -55,7 +58,7 @@ public class DissolutionCreatorTest {
     public static final String BARCODE = "BARC0D3";
 
     @Test
-    public void create_generatesAReferenceNumber_mapsToDissolution_savesInDatabase_returnsCreateResponse() {
+    public void create_generatesAReferenceNumber_mapsToDissolution_savesInDatabase_notifiesSignatories_returnsCreateResponse() {
         final DissolutionCreateRequest body = DissolutionFixtures.generateDissolutionCreateRequest();
 
         final Dissolution dissolution = DissolutionFixtures.generateDissolution();
@@ -74,8 +77,9 @@ public class DissolutionCreatorTest {
         verify(referenceGenerator).generateApplicationReference();
         verify(barcodeGenerator).generateBarcode();
         verify(requestMapper).mapToDissolution(body, company, directors, USER_ID, EMAIL, IP, REFERENCE, BARCODE);
-        verify(responseMapper).mapToDissolutionCreateResponse(dissolution);
         verify(repository).insert(dissolution);
+        verify(emailService).notifySignatoriesToSign(dissolution);
+        verify(responseMapper).mapToDissolutionCreateResponse(dissolution);
 
         assertEquals(response, result);
     }

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionDeadlineDateCalculatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionDeadlineDateCalculatorTest.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.service.dissolution;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DissolutionDeadlineDateCalculatorTest {
+
+    final DissolutionDeadlineDateCalculator calculator = new DissolutionDeadlineDateCalculator();
+
+    @Test
+    public void calculateSignatoryDeadlineDate_shouldReturnADateTwoWeeksAfterTheProvidedDate_andFormatIt() {
+        final LocalDateTime startDate = LocalDateTime.of(2020, 9, 3, 0, 0);
+
+        final String result = calculator.calculateSignatoryDeadlineDate(startDate);
+
+        assertEquals("17 September 2020", result);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/service/email/DissolutionEmailServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/email/DissolutionEmailServiceTest.java
@@ -10,17 +10,32 @@ import uk.gov.companieshouse.fixtures.EmailFixtures;
 import uk.gov.companieshouse.mapper.email.DissolutionEmailMapper;
 import uk.gov.companieshouse.mapper.email.EmailMapper;
 import uk.gov.companieshouse.model.db.dissolution.Dissolution;
+import uk.gov.companieshouse.model.db.dissolution.DissolutionDirector;
 import uk.gov.companieshouse.model.dto.email.EmailDocument;
+import uk.gov.companieshouse.model.dto.email.SignatoryToSignEmailData;
 import uk.gov.companieshouse.model.dto.email.SuccessfulPaymentEmailData;
+import uk.gov.companieshouse.service.dissolution.DissolutionDeadlineDateCalculator;
 import uk.gov.companieshouse.service.dissolution.DissolutionEmailService;
+
+import java.util.Arrays;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolution;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolutionDirector;
+import static uk.gov.companieshouse.fixtures.EmailFixtures.generateEmailDocument;
+import static uk.gov.companieshouse.fixtures.EmailFixtures.generateSignatoryToSignEmailData;
+import static uk.gov.companieshouse.model.Constants.SIGNATORY_TO_SIGN_MESSAGE_TYPE;
 
 @ExtendWith(MockitoExtension.class)
 public class DissolutionEmailServiceTest {
+
+    private static final String SIGNATORY_TO_SIGN_DEADLINE = "17 September 2020";
+    private static final String SIGNATORY_EMAIL_ONE = "signatory1@mail.com";
+    private static final String SIGNATORY_EMAIL_TWO = "signatory2@mail.com";
 
     @InjectMocks
     private DissolutionEmailService dissolutionEmailService;
@@ -29,16 +44,19 @@ public class DissolutionEmailServiceTest {
     private DissolutionEmailMapper dissolutionEmailMapper;
 
     @Mock
-    private EmailMapper<SuccessfulPaymentEmailData> emailMapper;
+    private EmailMapper emailMapper;
 
     @Mock
     private EmailService emailService;
 
+    @Mock
+    private DissolutionDeadlineDateCalculator deadlineDateCalculator;
+
     @Test
     public void sendSuccessfulPaymentEmail() {
-        final Dissolution dissolution = DissolutionFixtures.generateDissolution();
+        final Dissolution dissolution = generateDissolution();
         final SuccessfulPaymentEmailData successfulPaymentEmailData = EmailFixtures.generateSuccessfulPaymentEmailData();
-        final EmailDocument<SuccessfulPaymentEmailData> emailDocument = EmailFixtures.generateEmailDocument(successfulPaymentEmailData);
+        final EmailDocument<SuccessfulPaymentEmailData> emailDocument = generateEmailDocument(successfulPaymentEmailData);
 
         when(dissolutionEmailMapper.mapToSuccessfulPaymentEmailData(dissolution)).thenReturn(successfulPaymentEmailData);
         when(emailMapper.mapToEmailDocument(eq(successfulPaymentEmailData), eq(successfulPaymentEmailData.getTo()), any())).thenReturn(emailDocument);
@@ -46,5 +64,58 @@ public class DissolutionEmailServiceTest {
         dissolutionEmailService.sendSuccessfulPaymentEmail(dissolution);
 
         verify(emailService).sendMessage(emailDocument);
+    }
+
+    @Test
+    public void notifySignatoriesToSign_shouldCalculateDeadline_andIdentifyUniqueSignatories() {
+        final DissolutionDirector duplicateSignatoryOne = generateDissolutionDirector();
+        duplicateSignatoryOne.setEmail(SIGNATORY_EMAIL_ONE);
+
+        final DissolutionDirector duplicateSignatoryTwo = generateDissolutionDirector();
+        duplicateSignatoryTwo.setEmail(SIGNATORY_EMAIL_ONE);
+
+        final DissolutionDirector uniqueSignatory = generateDissolutionDirector();
+        duplicateSignatoryTwo.setEmail(SIGNATORY_EMAIL_TWO);
+
+        final Dissolution dissolution = generateDissolution();
+        dissolution.getData().setDirectors(Arrays.asList(duplicateSignatoryOne, duplicateSignatoryTwo, uniqueSignatory));
+
+        when(deadlineDateCalculator.calculateSignatoryDeadlineDate(any())).thenReturn(SIGNATORY_TO_SIGN_DEADLINE);
+
+        dissolutionEmailService.notifySignatoriesToSign(dissolution);
+
+        verify(deadlineDateCalculator).calculateSignatoryDeadlineDate(any());
+        verify(dissolutionEmailMapper, times(1)).mapToSignatoryToSignEmailData(dissolution, SIGNATORY_EMAIL_ONE, SIGNATORY_TO_SIGN_DEADLINE);
+        verify(dissolutionEmailMapper, times(1)).mapToSignatoryToSignEmailData(dissolution, SIGNATORY_EMAIL_TWO, SIGNATORY_TO_SIGN_DEADLINE);
+    }
+
+    @Test
+    public void notifySignatoriesToSign_shouldGenerateAndSendAnEmail_forEachUniqueSignatory() {
+        final DissolutionDirector signatoryOne = generateDissolutionDirector();
+        signatoryOne.setEmail(SIGNATORY_EMAIL_ONE);
+
+        final DissolutionDirector signatoryTwo = generateDissolutionDirector();
+        signatoryTwo.setEmail(SIGNATORY_EMAIL_TWO);
+
+        final Dissolution dissolution = generateDissolution();
+        dissolution.getData().setDirectors(Arrays.asList(signatoryOne, signatoryTwo));
+
+        final SignatoryToSignEmailData emailDataOne = generateSignatoryToSignEmailData();
+        final SignatoryToSignEmailData emailDataTwo = generateSignatoryToSignEmailData();
+
+        final EmailDocument<SignatoryToSignEmailData> emailOne = generateEmailDocument(emailDataOne);
+        final EmailDocument<SignatoryToSignEmailData> emailTwo = generateEmailDocument(emailDataTwo);
+
+        when(deadlineDateCalculator.calculateSignatoryDeadlineDate(any())).thenReturn(SIGNATORY_TO_SIGN_DEADLINE);
+        when(dissolutionEmailMapper.mapToSignatoryToSignEmailData(dissolution, SIGNATORY_EMAIL_ONE, SIGNATORY_TO_SIGN_DEADLINE)).thenReturn(emailDataOne);
+        when(dissolutionEmailMapper.mapToSignatoryToSignEmailData(dissolution, SIGNATORY_EMAIL_TWO, SIGNATORY_TO_SIGN_DEADLINE)).thenReturn(emailDataTwo);
+        when(emailMapper.mapToEmailDocument(emailDataOne, SIGNATORY_EMAIL_ONE, SIGNATORY_TO_SIGN_MESSAGE_TYPE)).thenReturn(emailOne);
+        when(emailMapper.mapToEmailDocument(emailDataTwo, SIGNATORY_EMAIL_TWO, SIGNATORY_TO_SIGN_MESSAGE_TYPE)).thenReturn(emailTwo);
+
+        dissolutionEmailService.notifySignatoriesToSign(dissolution);
+
+        verify(emailService, times(2)).sendMessage(any());
+        verify(emailService).sendMessage(emailOne);
+        verify(emailService).sendMessage(emailTwo);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/service/email/EmailServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/email/EmailServiceTest.java
@@ -28,7 +28,7 @@ public class EmailServiceTest {
     private EmailSerialiser emailSerialiser;
 
     @Mock
-    private EmailMapper<?> emailMapper;
+    private EmailMapper emailMapper;
 
     @Mock
     private CHKafkaProducer kafkaProducer;


### PR DESCRIPTION
dissolution-api - https://github.com/companieshouse/dissolution-api/pull/45
chs-notification-api - https://github.com/companieshouse/chs-notification-api/pull/192

# Description

* Sending an email called `dissolution-signatory-to-sign` to each unique signatory email address
* Removed class level generic from EmailMapper to prevent coupling to a single model per dependent. The generic is now method level rather than class level

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [x] 3 Amigos
- [ ] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [ ] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [x] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description