### PR TITLE
Add product type depending on the type of application

### DIFF
--- a/src/main/java/uk/gov/companieshouse/controller/PaymentController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/PaymentController.java
@@ -52,7 +52,7 @@ public class PaymentController {
                 .getByCompanyNumber(companyNumber)
                 .orElseThrow(NotFoundException::new);
 
-        return paymentService.get(dissolutionInfo.getETag(), companyNumber);
+        return paymentService.get(dissolutionInfo.getETag(), dissolutionInfo.getApplicationType(), companyNumber);
     }
 
     @Operation(summary = "Patch Payment Status", tags = "Dissolution")

--- a/src/main/java/uk/gov/companieshouse/model/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/model/Constants.java
@@ -14,7 +14,8 @@ public final class Constants {
    public static final String PAYMENT_RESOURCE_KIND = "dissolution-request#dissolution-request";
    public static final String PAYMENT_DESCRIPTION = "Dissolution application";
    public static final String PAYMENT_DESCRIPTION_IDENTIFIER = "Dissolution application";
-   public static final String PAYMENT_PRODUCT_TYPE = "Dissolution application";
+   public static final String PAYMENT_PRODUCT_TYPE_DS01 = "16032";
+   public static final String PAYMENT_PRODUCT_TYPE_LLDS01 = "16511";
    public static final String PAYMENT_AMOUNT = "8";
    public static final String PAYMENT_AVAILABLE_PAYMENT_METHOD = "credit-card";
    public static final String PAYMENT_CLASS_OF_PAYMENT = "data-maintenance";

--- a/src/main/java/uk/gov/companieshouse/model/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/model/Constants.java
@@ -14,8 +14,6 @@ public final class Constants {
    public static final String PAYMENT_RESOURCE_KIND = "dissolution-request#dissolution-request";
    public static final String PAYMENT_DESCRIPTION = "Dissolution application";
    public static final String PAYMENT_DESCRIPTION_IDENTIFIER = "Dissolution application";
-   public static final String PAYMENT_PRODUCT_TYPE_DS01 = "16032";
-   public static final String PAYMENT_PRODUCT_TYPE_LLDS01 = "16511";
    public static final String PAYMENT_AMOUNT = "8";
    public static final String PAYMENT_AVAILABLE_PAYMENT_METHOD = "credit-card";
    public static final String PAYMENT_CLASS_OF_PAYMENT = "data-maintenance";

--- a/src/main/java/uk/gov/companieshouse/model/dto/payment/PaymentItem.java
+++ b/src/main/java/uk/gov/companieshouse/model/dto/payment/PaymentItem.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.model.dto.payment;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.companieshouse.model.enums.ApplicationType;
 
 import java.util.List;
 
@@ -14,7 +15,7 @@ public class PaymentItem {
     private PaymentDescriptionValues descriptionValues;
 
     @JsonProperty("product_type")
-    private String productType;
+    private ApplicationType productType;
 
     private String amount;
 
@@ -53,11 +54,11 @@ public class PaymentItem {
         this.descriptionValues = descriptionValues;
     }
 
-    public String getProductType() {
+    public ApplicationType getProductType() {
         return productType;
     }
 
-    public void setProductType(String productType) {
+    public void setProductType(ApplicationType productType) {
         this.productType = productType;
     }
 

--- a/src/main/java/uk/gov/companieshouse/service/payment/PaymentService.java
+++ b/src/main/java/uk/gov/companieshouse/service/payment/PaymentService.java
@@ -36,7 +36,7 @@ public class PaymentService {
         item.setDescription(PAYMENT_DESCRIPTION);
         item.setDescriptionIdentifier(PAYMENT_DESCRIPTION_IDENTIFIER);
         item.setDescriptionValues(new PaymentDescriptionValues());
-        item.setProductType(getProductTypeCode(applicationType));
+        item.setProductType(applicationType);
         item.setAmount(PAYMENT_AMOUNT);
         item.setAvailablePaymentMethods(List.of(PAYMENT_AVAILABLE_PAYMENT_METHOD));
         item.setClassOfPayment(List.of(PAYMENT_CLASS_OF_PAYMENT));
@@ -44,9 +44,5 @@ public class PaymentService {
         item.setResourceKind(PAYMENT_RESOURCE_KIND);
 
         return item;
-    }
-
-    private String getProductTypeCode(ApplicationType applicationType) {
-        return applicationType == ApplicationType.DS01 ? PAYMENT_PRODUCT_TYPE_DS01 : PAYMENT_PRODUCT_TYPE_LLDS01;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/service/payment/PaymentService.java
+++ b/src/main/java/uk/gov/companieshouse/service/payment/PaymentService.java
@@ -5,6 +5,7 @@ import uk.gov.companieshouse.model.dto.payment.PaymentDescriptionValues;
 import uk.gov.companieshouse.model.dto.payment.PaymentGetResponse;
 import uk.gov.companieshouse.model.dto.payment.PaymentItem;
 import uk.gov.companieshouse.model.dto.payment.PaymentLinks;
+import uk.gov.companieshouse.model.enums.ApplicationType;
 
 import java.util.List;
 
@@ -13,13 +14,13 @@ import static uk.gov.companieshouse.model.Constants.*;
 @Service
 public class PaymentService {
 
-    public PaymentGetResponse get(String eTag, String companyNumber) {
+    public PaymentGetResponse get(String eTag, ApplicationType applicationType, String companyNumber) {
         PaymentGetResponse response = new PaymentGetResponse();
         PaymentLinks paymentLinks = new PaymentLinks();
         paymentLinks.setSelf("/dissolution-request/" + companyNumber + "/payment");
         paymentLinks.setDissolutionRequest("/dissolution-request/" + companyNumber);
 
-        PaymentItem item = createPaymentItem();
+        PaymentItem item = createPaymentItem(applicationType);
 
         response.setETag(eTag);
         response.setKind(PAYMENT_KIND);
@@ -29,13 +30,13 @@ public class PaymentService {
         return response;
     }
 
-    private PaymentItem createPaymentItem() {
+    private PaymentItem createPaymentItem(ApplicationType applicationType) {
         PaymentItem item = new PaymentItem();
 
         item.setDescription(PAYMENT_DESCRIPTION);
         item.setDescriptionIdentifier(PAYMENT_DESCRIPTION_IDENTIFIER);
         item.setDescriptionValues(new PaymentDescriptionValues());
-        item.setProductType(PAYMENT_PRODUCT_TYPE);
+        item.setProductType(getProductTypeCode(applicationType));
         item.setAmount(PAYMENT_AMOUNT);
         item.setAvailablePaymentMethods(List.of(PAYMENT_AVAILABLE_PAYMENT_METHOD));
         item.setClassOfPayment(List.of(PAYMENT_CLASS_OF_PAYMENT));
@@ -43,5 +44,9 @@ public class PaymentService {
         item.setResourceKind(PAYMENT_RESOURCE_KIND);
 
         return item;
+    }
+
+    private String getProductTypeCode(ApplicationType applicationType) {
+        return applicationType == ApplicationType.DS01 ? PAYMENT_PRODUCT_TYPE_DS01 : PAYMENT_PRODUCT_TYPE_LLDS01;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
@@ -24,9 +24,7 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -116,7 +114,7 @@ public class PaymentControllerTest {
         final PaymentGetResponse paymentGetResponse = generatePaymentGetResponse(dissolutionGetResponse.getETag(), COMPANY_NUMBER);
 
         when(dissolutionService.getByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(dissolutionGetResponse));
-        when(paymentService.get(dissolutionGetResponse.getETag(), COMPANY_NUMBER)).thenReturn(paymentGetResponse);
+        when(paymentService.get(dissolutionGetResponse.getETag(), dissolutionGetResponse.getApplicationType(), COMPANY_NUMBER)).thenReturn(paymentGetResponse);
 
         mockMvc
                 .perform(

--- a/src/test/java/uk/gov/companieshouse/fixtures/PaymentFixtures.java
+++ b/src/test/java/uk/gov/companieshouse/fixtures/PaymentFixtures.java
@@ -6,6 +6,7 @@ import uk.gov.companieshouse.model.dto.payment.PaymentGetResponse;
 import uk.gov.companieshouse.model.dto.payment.PaymentItem;
 import uk.gov.companieshouse.model.dto.payment.PaymentLinks;
 import uk.gov.companieshouse.model.dto.payment.PaymentPatchRequest;
+import uk.gov.companieshouse.model.enums.ApplicationType;
 import uk.gov.companieshouse.model.enums.PaymentMethod;
 import uk.gov.companieshouse.model.enums.PaymentStatus;
 
@@ -25,7 +26,7 @@ public class PaymentFixtures {
         item.setDescription("Dissolution application");
         item.setDescriptionIdentifier("Dissolution application");
         item.setDescriptionValues(new PaymentDescriptionValues());
-        item.setProductType("Dissolution application");
+        item.setProductType(ApplicationType.DS01);
         item.setAmount("8");
         item.setAvailablePaymentMethods(List.of("credit-card"));
         item.setClassOfPayment(List.of("data-maintenance"));

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/PaymentServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.model.dto.payment.PaymentGetResponse;
+import uk.gov.companieshouse.model.enums.ApplicationType;
 import uk.gov.companieshouse.service.payment.PaymentService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,11 +19,12 @@ public class PaymentServiceTest {
     private PaymentService service;
 
     @Test
-    public void get_getsPaymentUIData_returnsGetResponse() throws Exception {
+    public void get_getsPaymentUIData_returnsGetResponse() {
         final String companyNumber = "12345678";
         final String eTag = "WATERMELONSAREGREAT12345678THEYREALLYARE";
+        final ApplicationType applicationType = ApplicationType.DS01;
 
-        final PaymentGetResponse result = service.get(eTag, companyNumber);
+        final PaymentGetResponse result = service.get(eTag, applicationType, companyNumber);
 
         assertEquals(eTag, result.getETag());
         assertEquals(PAYMENT_KIND, result.getKind());
@@ -31,11 +33,32 @@ public class PaymentServiceTest {
         assertEquals(PAYMENT_DESCRIPTION, result.getItems().get(0).getDescription());
         assertEquals(PAYMENT_DESCRIPTION_IDENTIFIER, result.getItems().get(0).getDescriptionIdentifier());
         assertNotNull(result.getItems().get(0).getDescriptionValues());
-        assertEquals(PAYMENT_PRODUCT_TYPE, result.getItems().get(0).getProductType());
         assertEquals(PAYMENT_AMOUNT, result.getItems().get(0).getAmount());
         assertEquals(PAYMENT_AVAILABLE_PAYMENT_METHOD, result.getItems().get(0).getAvailablePaymentMethods().get(0));
         assertEquals(PAYMENT_CLASS_OF_PAYMENT, result.getItems().get(0).getClassOfPayment().get(0));
         assertEquals(PAYMENT_ITEM_KIND, result.getItems().get(0).getKind());
         assertEquals(PAYMENT_RESOURCE_KIND, result.getItems().get(0).getResourceKind());
+    }
+
+    @Test
+    public void get_getsPaymentUIData_returnsProperCodeForDS01() {
+        final String companyNumber = "12345678";
+        final String eTag = "WATERMELONSAREGREAT12345678THEYREALLYARE";
+        final ApplicationType applicationType = ApplicationType.DS01;
+
+        final PaymentGetResponse result = service.get(eTag, applicationType, companyNumber);
+
+        assertEquals(PAYMENT_PRODUCT_TYPE_DS01, result.getItems().get(0).getProductType());
+    }
+
+    @Test
+    public void get_getsPaymentUIData_returnsProperCodeForLLDS01() {
+        final String companyNumber = "12345678";
+        final String eTag = "WATERMELONSAREGREAT12345678THEYREALLYARE";
+        final ApplicationType applicationType = ApplicationType.LLDS01;
+
+        final PaymentGetResponse result = service.get(eTag, applicationType, companyNumber);
+
+        assertEquals(PAYMENT_PRODUCT_TYPE_LLDS01, result.getItems().get(0).getProductType());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/PaymentServiceTest.java
@@ -48,7 +48,7 @@ public class PaymentServiceTest {
 
         final PaymentGetResponse result = service.get(eTag, applicationType, companyNumber);
 
-        assertEquals(PAYMENT_PRODUCT_TYPE_DS01, result.getItems().get(0).getProductType());
+        assertEquals(ApplicationType.DS01, result.getItems().get(0).getProductType());
     }
 
     @Test
@@ -59,6 +59,7 @@ public class PaymentServiceTest {
 
         final PaymentGetResponse result = service.get(eTag, applicationType, companyNumber);
 
-        assertEquals(PAYMENT_PRODUCT_TYPE_LLDS01, result.getItems().get(0).getProductType());
+        System.out.println(result.getItems().get(0).getProductType());
+        assertEquals(ApplicationType.LLDS01, result.getItems().get(0).getProductType());
     }
 }


### PR DESCRIPTION
Update tests

# Description

Product type is now dependant on whether the application is DS01 or LLDS01

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ n/a] 3 Amigos
- [ x] Acceptance Criteria met
- [ x] Branch named {feature|hotfix|task}/{S4-*}
- [ x] Commit messages are meaningful
- [ x] Manually tested
- [ x] All unit tests passing
- [ x] API (Karate) tests passing
- [ x] Pulled latest master into feature branch
- [ x] Code reviewed
- [ n/a] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ n/a] If your pull request depends on any other, please link them in the description