### PR TITLE
Enable multiple dissolutions

### DIFF
--- a/src/main/java/uk/gov/companieshouse/mapper/DissolutionRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/DissolutionRequestMapper.java
@@ -31,6 +31,7 @@ public class DissolutionRequestMapper {
         dissolution.setData(mapToDissolutionData(body, company.getType(), directors, reference, barcode));
         dissolution.setCompany(mapToCompany(company.getCompanyNumber(), company.getCompanyName()));
         dissolution.setCreatedBy(mapToCreatedBy(userId, email, ip));
+        dissolution.setActive(true);
 
         return dissolution;
     }

--- a/src/main/java/uk/gov/companieshouse/model/db/dissolution/Dissolution.java
+++ b/src/main/java/uk/gov/companieshouse/model/db/dissolution/Dissolution.java
@@ -31,6 +31,16 @@ public class Dissolution {
 
     private DissolutionVerdict verdict;
 
+    boolean active;
+    
+    public boolean getActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+    
     public String getId() {
         return id;
     }

--- a/src/main/java/uk/gov/companieshouse/repository/DissolutionRepository.java
+++ b/src/main/java/uk/gov/companieshouse/repository/DissolutionRepository.java
@@ -15,6 +15,7 @@ public interface DissolutionRepository extends MongoRepository<Dissolution, Stri
 
     Dissolution insert(Dissolution dissolution);
 
+    @Query("{'company.number': ?0, 'active' : true}")
     Optional<Dissolution> findByCompanyNumber(String companyNumber);
 
     Optional<Dissolution> findByDataApplicationReference(String applicationReferenceNumber);

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/chips/ChipsResponseService.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/chips/ChipsResponseService.java
@@ -35,6 +35,7 @@ public class ChipsResponseService {
         Dissolution dissolution = this.repository.findByDataApplicationReference(body.getSubmissionReference()).get();
 
         dissolution.setVerdict(dissolutionVerdict);
+        dissolution.setActive(false);
 
         logger.info(String.format("Received CHIPS verdict for company %s - %s", dissolution.getCompany().getNumber(), dissolutionVerdict.getResult().toString()));
 

--- a/src/test/java/uk/gov/companieshouse/fixtures/DissolutionFixtures.java
+++ b/src/test/java/uk/gov/companieshouse/fixtures/DissolutionFixtures.java
@@ -80,6 +80,7 @@ public class DissolutionFixtures {
         dissolution.setSubmission(new DissolutionSubmission());
         dissolution.setPaymentInformation(new PaymentInformation());
         dissolution.setVerdict(new DissolutionVerdict());
+        dissolution.setActive(true);
 
         return dissolution;
     }

--- a/src/test/java/uk/gov/companieshouse/mapper/DissolutionRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/DissolutionRequestMapperTest.java
@@ -59,6 +59,7 @@ public class DissolutionRequestMapperTest {
 
         assertEquals(BARCODE, dissolution.getData().getApplication().getBarcode());
         assertEquals(REFERENCE, dissolution.getData().getApplication().getReference());
+        assertTrue(dissolution.getActive());
         assertEquals(ApplicationStatus.PENDING_APPROVAL, dissolution.getData().getApplication().getStatus());
         assertEquals(ApplicationType.DS01, dissolution.getData().getApplication().getType());
     }
@@ -76,6 +77,7 @@ public class DissolutionRequestMapperTest {
 
         assertEquals(BARCODE, dissolution.getData().getApplication().getBarcode());
         assertEquals(REFERENCE, dissolution.getData().getApplication().getReference());
+        assertTrue(dissolution.getActive());
         assertEquals(ApplicationStatus.PENDING_APPROVAL, dissolution.getData().getApplication().getStatus());
         assertEquals(ApplicationType.LLDS01, dissolution.getData().getApplication().getType());
     }

--- a/src/test/java/uk/gov/companieshouse/repository/dissolution/DissolutionRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/repository/dissolution/DissolutionRepositoryTest.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataMongoTest
 @ExtendWith(SpringExtension.class)
@@ -25,15 +26,29 @@ public class DissolutionRepositoryTest {
     public DissolutionRepository repository;
 
     @Test
-    public void findByCompanyNumber_findsCorrectDissolution() {
+    public void findByCompanyNumber_findsActiveDissolution() {
         final String COMPANY_NUMBER = "123";
 
         Dissolution dissolution = DissolutionFixtures.generateDissolution();
         dissolution.getCompany().setNumber(COMPANY_NUMBER);
+        dissolution.setActive(true);
 
         repository.insert(dissolution);
 
         assertEquals(COMPANY_NUMBER, repository.findByCompanyNumber(COMPANY_NUMBER).get().getCompany().getNumber());
+    }
+
+    @Test
+    public void findByCompanyNumber_DoesNotFindInactiveDissolution() {
+        final String COMPANY_NUMBER = "123";
+
+        Dissolution dissolution = DissolutionFixtures.generateDissolution();
+        dissolution.getCompany().setNumber(COMPANY_NUMBER);
+        dissolution.setActive(false);
+
+        repository.insert(dissolution);
+
+        assertTrue(repository.findByCompanyNumber(COMPANY_NUMBER).isEmpty());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/chips/ChipsResponseServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/chips/ChipsResponseServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.companieshouse.service.dissolution.DissolutionEmailService;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -48,6 +49,8 @@ public class ChipsResponseServiceTest {
         when(repository.findByDataApplicationReference(chipsResponseCreateRequest.getSubmissionReference())).thenReturn(Optional.of(dissolution));
 
         chipsResponseService.saveAndNotifyDissolutionApplicationOutcome(chipsResponseCreateRequest);
+        
+        assertFalse(dissolution.getActive());
 
         verify(dissolutionEmailService).sendApplicationOutcomeEmail(dissolution, dissolutionVerdict);
     }


### PR DESCRIPTION
## Description

Mark dissolutions as active when saving to Mongo
Fetch only active Dissolution
Mark dissolution as inactive when verdict is received from CHIPS

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [x] API (Karate) tests passing
- [x] Pulled latest master into feature branch
- [x] Code reviewed
- [n/a] New Docker environment variables have also been added to the rebel1 environment and cidev environment
- [n/a] If your pull request depends on any other, please link them in the description