### PR TITLE
hotfix/S4-297 - Handle companies as directors

### DIFF
--- a/src/main/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapper.java
@@ -124,8 +124,12 @@ public class ChipsFormDataMapper {
         final ChipsPersonName personName = new ChipsPersonName();
         final int nameSeparatorIndex = name.indexOf(',');
 
-        personName.setForename(name.substring(nameSeparatorIndex + 1).trim());
-        personName.setSurname(name.substring(0, nameSeparatorIndex).trim());
+        if (nameSeparatorIndex == -1) {
+            personName.setSurname(name.trim());
+        } else {
+            personName.setForename(name.substring(nameSeparatorIndex + 1).trim());
+            personName.setSurname(name.substring(0, nameSeparatorIndex).trim());
+        }
 
         return personName;
     }

--- a/src/test/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapperTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -188,7 +189,7 @@ public class ChipsFormDataMapperTest {
         approvalTwo.setDateTime(LocalDateTime.of(2020, 2, 2, 16, 15));
 
         DissolutionDirector directorTwo = generateDissolutionDirector();
-        directorTwo.setName("SMITH, Jane Janet, Mrs");
+        directorTwo.setName("ST.MARCUS CORPORATION");
         directorTwo.setDirectorApproval(approvalTwo);
         directorTwo.setEmail("mail2");
         directorTwo.setOnBehalfName("Mr. Accountant");
@@ -209,8 +210,8 @@ public class ChipsFormDataMapperTest {
         assertEquals("mail1", request.getCorporateBody().getOfficers().get(0).getEmail());
         assertEquals("192.168.0.2", request.getCorporateBody().getOfficers().get(0).getIpAddress());
 
-        assertEquals("Jane Janet, Mrs", request.getCorporateBody().getOfficers().get(1).getPersonName().getForename());
-        assertEquals("SMITH", request.getCorporateBody().getOfficers().get(1).getPersonName().getSurname());
+        assertNull(request.getCorporateBody().getOfficers().get(1).getPersonName().getForename());
+        assertEquals("ST.MARCUS CORPORATION", request.getCorporateBody().getOfficers().get(1).getPersonName().getSurname());
         assertEquals("2020-02-02", request.getCorporateBody().getOfficers().get(1).getSignDate());
         assertEquals("mail2", request.getCorporateBody().getOfficers().get(1).getEmail());
         assertEquals("Mr. Accountant", request.getCorporateBody().getOfficers().get(1).getOnBehalfName());


### PR DESCRIPTION
## Description

An officer with a name `DOE, John James` is sent to CHIPS as:
```
                <personName>
                    <forename>John James</forename>
                    <surname>DOE</surname>
                </personName>
```

But for some companies, another company can be listed as a director. Companies do not neccessarily have commas in their names, and caused the CHIPS submission code to break. Such names such be submitted as:
```
                <personName>
                    <surname>I AM A COMPANY</surname>
                </personName>
```

## Jira Ticket

Please add link to Jira ticket

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [ ] Branch named {feature|hotfix|task}/{S4-*}
- [ ] Commit messages are meaningful
- [ ] Manually tested
- [ ] All unit tests passing
- [ ] API (Karate) tests passing
- [ ] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description
