### PR TITLE
S4-279: Fix for incorrect IP being stored by patch request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/controller/DissolutionController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/DissolutionController.java
@@ -119,7 +119,8 @@ public class DissolutionController {
             @RequestHeader("ERIC-identity") String userId,
             @PathVariable("company-number") final String companyNumber,
             @Valid @RequestBody final DissolutionPatchRequest body,
-            HttpServletRequest request) {
+            HttpServletRequest request
+            ) {
 
         if (!dissolutionService.doesDissolutionRequestExistForCompanyByCompanyNumber(companyNumber)) {
             throw new NotFoundException();
@@ -130,7 +131,7 @@ public class DissolutionController {
         }
 
         try {
-            return dissolutionService.addDirectorApproval(companyNumber, userId, request.getRemoteAddr(), body.getOfficerId());
+            return dissolutionService.addDirectorApproval(companyNumber, userId, body);
         } catch (DissolutionNotFoundException e) {
             throw new NotFoundException();
         }

--- a/src/main/java/uk/gov/companieshouse/model/dto/dissolution/DissolutionPatchRequest.java
+++ b/src/main/java/uk/gov/companieshouse/model/dto/dissolution/DissolutionPatchRequest.java
@@ -15,6 +15,10 @@ public class DissolutionPatchRequest {
     @JsonProperty("has_approved")
     private boolean hasApproved;
 
+    @NotBlank
+    @JsonProperty("ip_address")
+    private String ipAddress;
+
     public String getOfficerId() {
         return officerId;
     }
@@ -30,4 +34,8 @@ public class DissolutionPatchRequest {
     public void setHasApproved(boolean hasApproved) {
         this.hasApproved = hasApproved;
     }
+
+    public String getIpAddress() { return ipAddress; }
+
+    public void setIpAddress(String ipAddress) { this.ipAddress = ipAddress; }
 }

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionPatcher.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionPatcher.java
@@ -11,6 +11,7 @@ import uk.gov.companieshouse.model.db.dissolution.DirectorApproval;
 import uk.gov.companieshouse.model.db.dissolution.Dissolution;
 import uk.gov.companieshouse.model.db.dissolution.DissolutionDirector;
 import uk.gov.companieshouse.model.db.payment.PaymentInformation;
+import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchRequest;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchResponse;
 import uk.gov.companieshouse.model.enums.ApplicationStatus;
 import uk.gov.companieshouse.model.enums.PaymentMethod;
@@ -49,10 +50,10 @@ public class DissolutionPatcher {
         this.dissolutionEmailService = dissolutionEmailService;
     }
 
-    public DissolutionPatchResponse addDirectorApproval(String companyNumber, String userId, String ip, String officerId) throws DissolutionNotFoundException {
+    public DissolutionPatchResponse addDirectorApproval(String companyNumber, String userId, DissolutionPatchRequest body) throws DissolutionNotFoundException {
         final Dissolution dissolution = this.repository.findByCompanyNumber(companyNumber).orElseThrow(DissolutionNotFoundException::new);
 
-        this.addDirectorApproval(userId, ip, officerId, dissolution);
+        this.addDirectorApproval(userId, body, dissolution);
 
         if (!this.hasDirectorsLeftToApprove(dissolution)) {
             handleFinalApproval(dissolution);
@@ -99,9 +100,9 @@ public class DissolutionPatcher {
         dissolution.setPaymentInformation(information);
     }
 
-    private void addDirectorApproval(String userId, String ip, String officerId, Dissolution dissolution) throws DissolutionNotFoundException {
-        final DirectorApproval approval = approvalMapper.mapToDirectorApproval(userId, ip);
-        DissolutionDirector director = this.findDirector(officerId, dissolution);
+    private void addDirectorApproval(String userId, DissolutionPatchRequest body, Dissolution dissolution) throws DissolutionNotFoundException {
+        final DirectorApproval approval = approvalMapper.mapToDirectorApproval(userId, body.getIpAddress());
+        DissolutionDirector director = this.findDirector(body.getOfficerId(), dissolution);
         director.setDirectorApproval(approval);
     }
 

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionService.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionService.java
@@ -5,10 +5,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.exception.DissolutionNotFoundException;
 import uk.gov.companieshouse.model.dto.companyofficers.CompanyOfficer;
 import uk.gov.companieshouse.model.dto.companyprofile.CompanyProfile;
-import uk.gov.companieshouse.model.dto.dissolution.DissolutionCreateRequest;
-import uk.gov.companieshouse.model.dto.dissolution.DissolutionCreateResponse;
-import uk.gov.companieshouse.model.dto.dissolution.DissolutionGetResponse;
-import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchResponse;
+import uk.gov.companieshouse.model.dto.dissolution.*;
 import uk.gov.companieshouse.model.dto.payment.PaymentPatchRequest;
 import uk.gov.companieshouse.repository.DissolutionRepository;
 
@@ -35,8 +32,8 @@ public class DissolutionService {
         return creator.create(body, companyProfile, directors, userId, ip, email);
     }
 
-    public DissolutionPatchResponse addDirectorApproval(String companyNumber, String userId, String ip, String officerId) throws DissolutionNotFoundException {
-        return patcher.addDirectorApproval(companyNumber, userId, ip, officerId);
+    public DissolutionPatchResponse addDirectorApproval(String companyNumber, String userId, DissolutionPatchRequest body) throws DissolutionNotFoundException {
+        return patcher.addDirectorApproval(companyNumber, userId, body);
     }
 
     public void handlePayment(PaymentPatchRequest data, String companyNumber) throws DissolutionNotFoundException {

--- a/src/test/java/uk/gov/companieshouse/fixtures/DissolutionFixtures.java
+++ b/src/test/java/uk/gov/companieshouse/fixtures/DissolutionFixtures.java
@@ -38,6 +38,7 @@ public class DissolutionFixtures {
 
         request.setOfficerId("abc123");
         request.setHasApproved(true);
+        request.setIpAddress("127.0.0.1");
 
         return request;
     }

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionServiceTest.java
@@ -10,10 +10,7 @@ import uk.gov.companieshouse.fixtures.CompanyProfileFixtures;
 import uk.gov.companieshouse.fixtures.DissolutionFixtures;
 import uk.gov.companieshouse.model.dto.companyofficers.CompanyOfficer;
 import uk.gov.companieshouse.model.dto.companyprofile.CompanyProfile;
-import uk.gov.companieshouse.model.dto.dissolution.DissolutionCreateRequest;
-import uk.gov.companieshouse.model.dto.dissolution.DissolutionCreateResponse;
-import uk.gov.companieshouse.model.dto.dissolution.DissolutionGetResponse;
-import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchResponse;
+import uk.gov.companieshouse.model.dto.dissolution.*;
 import uk.gov.companieshouse.model.dto.payment.PaymentPatchRequest;
 import uk.gov.companieshouse.repository.DissolutionRepository;
 
@@ -24,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.fixtures.CompanyOfficerFixtures.generateCompanyOfficer;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolutionPatchRequest;
 import static uk.gov.companieshouse.fixtures.PaymentFixtures.generatePaymentPatchRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -119,13 +117,17 @@ public class DissolutionServiceTest {
 
     @Test
     public void addDirectorApproval_addsDirectorApproval_returnsPatchResponse() throws DissolutionNotFoundException {
+        final DissolutionPatchRequest body = generateDissolutionPatchRequest();
+        body.setIpAddress(IP);
+        body.setOfficerId(OFFICER_ID);
+
         final DissolutionPatchResponse response = DissolutionFixtures.generateDissolutionPatchResponse();
 
-        when(patcher.addDirectorApproval(COMPANY_NUMBER, USER_ID, IP, OFFICER_ID)).thenReturn(response);
+        when(patcher.addDirectorApproval(COMPANY_NUMBER, USER_ID, body)).thenReturn(response);
 
-        final DissolutionPatchResponse result = service.addDirectorApproval(COMPANY_NUMBER, USER_ID, IP, OFFICER_ID);
+        final DissolutionPatchResponse result = service.addDirectorApproval(COMPANY_NUMBER, USER_ID, body);
 
-        verify(patcher).addDirectorApproval(COMPANY_NUMBER, USER_ID, IP, OFFICER_ID);
+        verify(patcher).addDirectorApproval(COMPANY_NUMBER, USER_ID, body);
 
         assertNotNull(result);
         assertEquals(response, result);


### PR DESCRIPTION
- Added recieving IP from patch request

## Description

Added IP to the patch request model so that we can store the correct IP address

## Jira Ticket

https://companieshouse.atlassian.net/browse/S4-279

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [x] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description
