### PR TITLE
Use application reference instead of company number in payment endpoints

### DIFF
--- a/src/main/java/uk/gov/companieshouse/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/config/SecurityConfig.java
@@ -15,7 +15,7 @@ public class SecurityConfig implements WebMvcConfigurer {
     private static final String URI_PATTERN = "/dissolution-request/**";
 
     private static final String[] API_KEY_PERMISSION_AUTH_INCLUDE_LIST = {
-            "/dissolution-request/{company-number}/payment",
+            "/dissolution-request/{application-reference}/payment",
             "/dissolution-request/submit",
             "/dissolution-request/response"
     };

--- a/src/main/java/uk/gov/companieshouse/controller/PaymentController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/PaymentController.java
@@ -53,7 +53,7 @@ public class PaymentController {
                 .getByApplicationReference(applicationReference)
                 .orElseThrow(NotFoundException::new);
 
-        return paymentService.get(dissolutionInfo, applicationReference);
+        return paymentService.get(dissolutionInfo);
     }
 
     @Operation(summary = "Patch Payment Status", tags = "Dissolution")

--- a/src/main/java/uk/gov/companieshouse/mapper/DissolutionResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/DissolutionResponseMapper.java
@@ -19,8 +19,10 @@ public class DissolutionResponseMapper {
     public DissolutionCreateResponse mapToDissolutionCreateResponse(Dissolution dissolution) {
         final DissolutionCreateResponse response = new DissolutionCreateResponse();
 
-        response.setApplicationReferenceNumber(dissolution.getData().getApplication().getReference());
-        response.setLinks(generateLinks(dissolution.getCompany().getNumber()));
+        final String reference = dissolution.getData().getApplication().getReference();
+
+        response.setApplicationReferenceNumber(reference);
+        response.setLinks(generateLinks(dissolution.getCompany().getNumber(), reference));
 
         return response;
     }
@@ -28,11 +30,13 @@ public class DissolutionResponseMapper {
     public DissolutionGetResponse mapToDissolutionGetResponse(Dissolution dissolution) {
         final DissolutionGetResponse response = new DissolutionGetResponse();
 
+        final String reference = dissolution.getData().getApplication().getReference();
+
         response.setETag(dissolution.getData().getETag());
         response.setKind(DISSOLUTION_KIND);
-        response.setLinks(generateLinks(dissolution.getCompany().getNumber()));
+        response.setLinks(generateLinks(dissolution.getCompany().getNumber(), reference));
         response.setApplicationStatus(dissolution.getData().getApplication().getStatus());
-        response.setApplicationReference(dissolution.getData().getApplication().getReference());
+        response.setApplicationReference(reference);
         response.setApplicationType(dissolution.getData().getApplication().getType());
         response.setCompanyName(dissolution.getCompany().getName());
         response.setCompanyNumber(dissolution.getCompany().getNumber());
@@ -47,18 +51,22 @@ public class DissolutionResponseMapper {
         return response;
     }
 
-    public DissolutionPatchResponse mapToDissolutionPatchResponse(String companyNumber) {
+    public DissolutionPatchResponse mapToDissolutionPatchResponse(Dissolution dissolution) {
         final DissolutionPatchResponse response = new DissolutionPatchResponse();
 
-        response.setLinks(generateLinks(companyNumber));
+        response.setLinks(generateLinks(
+                dissolution.getCompany().getNumber(),
+                dissolution.getData().getApplication().getReference()
+        ));
+
         return response;
     }
 
-    private DissolutionLinks generateLinks(String companyNumber) {
+    private DissolutionLinks generateLinks(String companyNumber, String reference) {
         final DissolutionLinks links = new DissolutionLinks();
 
         links.setSelf(String.format("/dissolution-request/%s", companyNumber));
-        links.setPayment(String.format("/dissolution-request/%s/payment", companyNumber));
+        links.setPayment(String.format("/dissolution-request/%s/payment", reference));
 
         return links;
     }

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionGetter.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionGetter.java
@@ -29,6 +29,12 @@ public class DissolutionGetter {
                 .map(responseMapper::mapToDissolutionGetResponse);
     }
 
+    public Optional<DissolutionGetResponse> getByApplicationReference(String applicationReference) {
+        return repository
+                .findByDataApplicationReference(applicationReference)
+                .map(responseMapper::mapToDissolutionGetResponse);
+    }
+
     public boolean isDirectorPendingApproval(String companyNumber, String officerId) {
         return repository.findByCompanyNumber(companyNumber)
                 .map(dissolution -> isDirectorPendingApprovalForDissolution(officerId, dissolution))

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionPatcher.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionPatcher.java
@@ -61,7 +61,7 @@ public class DissolutionPatcher {
 
         this.repository.save(dissolution);
 
-        return this.responseMapper.mapToDissolutionPatchResponse(companyNumber);
+        return this.responseMapper.mapToDissolutionPatchResponse(dissolution);
     }
 
     private void handleFinalApproval(Dissolution dissolution) {

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionService.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionService.java
@@ -5,7 +5,11 @@ import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.exception.DissolutionNotFoundException;
 import uk.gov.companieshouse.model.dto.companyofficers.CompanyOfficer;
 import uk.gov.companieshouse.model.dto.companyprofile.CompanyProfile;
-import uk.gov.companieshouse.model.dto.dissolution.*;
+import uk.gov.companieshouse.model.dto.dissolution.DissolutionCreateRequest;
+import uk.gov.companieshouse.model.dto.dissolution.DissolutionCreateResponse;
+import uk.gov.companieshouse.model.dto.dissolution.DissolutionGetResponse;
+import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchRequest;
+import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchResponse;
 import uk.gov.companieshouse.model.dto.payment.PaymentPatchRequest;
 import uk.gov.companieshouse.repository.DissolutionRepository;
 
@@ -50,6 +54,10 @@ public class DissolutionService {
 
     public Optional<DissolutionGetResponse> getByCompanyNumber(String companyNumber) {
         return getter.getByCompanyNumber(companyNumber);
+    }
+
+    public Optional<DissolutionGetResponse> getByApplicationReference(String applicationReference) {
+        return getter.getByApplicationReference(applicationReference);
     }
 
     public boolean isDirectorPendingApproval(String companyNumber, String officerId) {

--- a/src/main/java/uk/gov/companieshouse/service/payment/PaymentService.java
+++ b/src/main/java/uk/gov/companieshouse/service/payment/PaymentService.java
@@ -15,11 +15,11 @@ import static uk.gov.companieshouse.model.Constants.*;
 @Service
 public class PaymentService {
 
-    public PaymentGetResponse get(DissolutionGetResponse dissolutionInfo, String applicationReference) {
+    public PaymentGetResponse get(DissolutionGetResponse dissolutionInfo) {
         PaymentGetResponse response = new PaymentGetResponse();
         PaymentLinks paymentLinks = new PaymentLinks();
-        paymentLinks.setSelf("/dissolution-request/" + applicationReference + "/payment");
-        paymentLinks.setDissolutionRequest("/dissolution-request/" + applicationReference);
+        paymentLinks.setSelf("/dissolution-request/" + dissolutionInfo.getApplicationReference() + "/payment");
+        paymentLinks.setDissolutionRequest("/dissolution-request/" + dissolutionInfo.getCompanyNumber());
 
         PaymentItem item = createPaymentItem(dissolutionInfo.getApplicationType());
 

--- a/src/main/java/uk/gov/companieshouse/service/payment/PaymentService.java
+++ b/src/main/java/uk/gov/companieshouse/service/payment/PaymentService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.service.payment;
 
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.model.dto.dissolution.DissolutionGetResponse;
 import uk.gov.companieshouse.model.dto.payment.PaymentDescriptionValues;
 import uk.gov.companieshouse.model.dto.payment.PaymentGetResponse;
 import uk.gov.companieshouse.model.dto.payment.PaymentItem;
@@ -14,18 +15,18 @@ import static uk.gov.companieshouse.model.Constants.*;
 @Service
 public class PaymentService {
 
-    public PaymentGetResponse get(String eTag, ApplicationType applicationType, String companyNumber) {
+    public PaymentGetResponse get(DissolutionGetResponse dissolutionInfo, String applicationReference) {
         PaymentGetResponse response = new PaymentGetResponse();
         PaymentLinks paymentLinks = new PaymentLinks();
-        paymentLinks.setSelf("/dissolution-request/" + companyNumber + "/payment");
-        paymentLinks.setDissolutionRequest("/dissolution-request/" + companyNumber);
+        paymentLinks.setSelf("/dissolution-request/" + applicationReference + "/payment");
+        paymentLinks.setDissolutionRequest("/dissolution-request/" + applicationReference);
 
-        PaymentItem item = createPaymentItem(applicationType);
+        PaymentItem item = createPaymentItem(dissolutionInfo.getApplicationType());
 
-        response.setETag(eTag);
+        response.setETag(dissolutionInfo.getETag());
         response.setKind(PAYMENT_KIND);
         response.setLinks(paymentLinks);
-        response.setCompanyNumber(companyNumber);
+        response.setCompanyNumber(dissolutionInfo.getCompanyNumber());
         response.setItems(List.of(item));
 
         return response;

--- a/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
@@ -39,7 +39,7 @@ import static uk.gov.companieshouse.fixtures.PaymentFixtures.generatePaymentPatc
 public class PaymentControllerTest {
 
     private static final String PAYMENT_URI = "/dissolution-request/{company-number}/payment";
-    private static final String COMPANY_NUMBER = "12345678";
+    private static final String APPLICATION_REFERENCE = "12345678";
 
     private static final String IDENTITY_HEADER_VALUE = "identity";
 
@@ -61,7 +61,7 @@ public class PaymentControllerTest {
 
         mockMvc
                 .perform(
-                        get(PAYMENT_URI, COMPANY_NUMBER)
+                        get(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .headers(headers)
                 )
@@ -75,7 +75,7 @@ public class PaymentControllerTest {
 
         mockMvc
                 .perform(
-                        get(PAYMENT_URI, COMPANY_NUMBER)
+                        get(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .headers(headers)
                 )
@@ -89,7 +89,7 @@ public class PaymentControllerTest {
 
         mockMvc
                 .perform(
-                        get(PAYMENT_URI, COMPANY_NUMBER)
+                        get(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .headers(headers)
                 )
@@ -98,11 +98,11 @@ public class PaymentControllerTest {
 
     @Test
     public void getPaymentUIDataRequest_returnsNotFound_ifDissolutionDoesntExist() throws Exception {
-        when(dissolutionService.getByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.empty());
+        when(dissolutionService.getByApplicationReference(APPLICATION_REFERENCE)).thenReturn(Optional.empty());
 
         mockMvc
                 .perform(
-                        get(PAYMENT_URI, COMPANY_NUMBER)
+                        get(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .headers(createHttpHeaders())
                 )
@@ -112,14 +112,14 @@ public class PaymentControllerTest {
     @Test
     public void getPaymentUIDataRequest_returnsPaymentUIData_ifRequestIsValid() throws Exception {
         final DissolutionGetResponse dissolutionGetResponse = generateDissolutionGetResponse();
-        final PaymentGetResponse paymentGetResponse = generatePaymentGetResponse(dissolutionGetResponse.getETag(), COMPANY_NUMBER);
+        final PaymentGetResponse paymentGetResponse = generatePaymentGetResponse(dissolutionGetResponse.getETag(), APPLICATION_REFERENCE);
 
-        when(dissolutionService.getByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(dissolutionGetResponse));
-        when(paymentService.get(dissolutionGetResponse.getETag(), dissolutionGetResponse.getApplicationType(), COMPANY_NUMBER)).thenReturn(paymentGetResponse);
+        when(dissolutionService.getByApplicationReference(APPLICATION_REFERENCE)).thenReturn(Optional.of(dissolutionGetResponse));
+        when(paymentService.get(dissolutionGetResponse, APPLICATION_REFERENCE)).thenReturn(paymentGetResponse);
 
         mockMvc
                 .perform(
-                        get(PAYMENT_URI, COMPANY_NUMBER)
+                        get(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .headers(createHttpHeaders())
                 )
@@ -134,7 +134,7 @@ public class PaymentControllerTest {
 
         mockMvc
                 .perform(
-                        patch(PAYMENT_URI, COMPANY_NUMBER)
+                        patch(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .headers(headers)
                 )
@@ -148,7 +148,7 @@ public class PaymentControllerTest {
 
         mockMvc
                 .perform(
-                        patch(PAYMENT_URI, COMPANY_NUMBER)
+                        patch(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .headers(headers)
                 )
@@ -162,7 +162,7 @@ public class PaymentControllerTest {
 
         mockMvc
                 .perform(
-                        patch(PAYMENT_URI, COMPANY_NUMBER)
+                        patch(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .headers(headers)
                 )
@@ -173,11 +173,11 @@ public class PaymentControllerTest {
     public void patchPaymentDataRequest_returnsNotFound_ifDissolutionDoesntExist() throws Exception {
         final PaymentPatchRequest body = generatePaymentPatchRequest();
 
-        when(dissolutionService.getByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.empty());
+        when(dissolutionService.getByApplicationReference(APPLICATION_REFERENCE)).thenReturn(Optional.empty());
 
         mockMvc
                 .perform(
-                        patch(PAYMENT_URI, COMPANY_NUMBER)
+                        patch(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .content(asJsonString(body))
                                 .headers(createHttpHeaders())
@@ -192,11 +192,11 @@ public class PaymentControllerTest {
 
         final PaymentPatchRequest body = generatePaymentPatchRequest();
 
-        when(dissolutionService.getByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(dissolutionGetResponse));
+        when(dissolutionService.getByApplicationReference(APPLICATION_REFERENCE)).thenReturn(Optional.of(dissolutionGetResponse));
 
         mockMvc
                 .perform(
-                        patch(PAYMENT_URI, COMPANY_NUMBER)
+                        patch(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .content(asJsonString(body))
                                 .headers(createHttpHeaders())
@@ -212,18 +212,18 @@ public class PaymentControllerTest {
         final PaymentPatchRequest body = generatePaymentPatchRequest();
         body.setStatus(PaymentStatus.PAID);
 
-        when(dissolutionService.getByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(dissolutionGetResponse));
+        when(dissolutionService.getByApplicationReference(APPLICATION_REFERENCE)).thenReturn(Optional.of(dissolutionGetResponse));
 
         mockMvc
                 .perform(
-                        patch(PAYMENT_URI, COMPANY_NUMBER)
+                        patch(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .content(asJsonString(body))
                                 .headers(createHttpHeaders())
                 )
                 .andExpect(status().isOk());
 
-        verify(dissolutionService).handlePayment(isA(PaymentPatchRequest.class), eq(COMPANY_NUMBER));
+        verify(dissolutionService).handlePayment(isA(PaymentPatchRequest.class), eq(APPLICATION_REFERENCE));
     }
 
     @Test
@@ -234,18 +234,18 @@ public class PaymentControllerTest {
         final PaymentPatchRequest body = generatePaymentPatchRequest();
         body.setStatus(PaymentStatus.FAILED);
 
-        when(dissolutionService.getByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(dissolutionGetResponse));
+        when(dissolutionService.getByApplicationReference(APPLICATION_REFERENCE)).thenReturn(Optional.of(dissolutionGetResponse));
 
         mockMvc
                 .perform(
-                        patch(PAYMENT_URI, COMPANY_NUMBER)
+                        patch(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .content(asJsonString(body))
                                 .headers(createHttpHeaders())
                 )
                 .andExpect(status().isOk());
 
-        verify(dissolutionService, never()).handlePayment(isA(PaymentPatchRequest.class), eq(COMPANY_NUMBER));
+        verify(dissolutionService, never()).handlePayment(isA(PaymentPatchRequest.class), eq(APPLICATION_REFERENCE));
     }
 
     @Test
@@ -256,18 +256,18 @@ public class PaymentControllerTest {
         final PaymentPatchRequest body = generatePaymentPatchRequest();
         body.setStatus(PaymentStatus.CANCELLED);
 
-        when(dissolutionService.getByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.of(dissolutionGetResponse));
+        when(dissolutionService.getByApplicationReference(APPLICATION_REFERENCE)).thenReturn(Optional.of(dissolutionGetResponse));
 
         mockMvc
                 .perform(
-                        patch(PAYMENT_URI, COMPANY_NUMBER)
+                        patch(PAYMENT_URI, APPLICATION_REFERENCE)
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .content(asJsonString(body))
                                 .headers(createHttpHeaders())
                 )
                 .andExpect(status().isOk());
 
-        verify(dissolutionService, never()).handlePayment(isA(PaymentPatchRequest.class), eq(COMPANY_NUMBER));
+        verify(dissolutionService, never()).handlePayment(isA(PaymentPatchRequest.class), eq(APPLICATION_REFERENCE));
     }
 
     private HttpHeaders createHttpHeaders() {

--- a/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
@@ -115,7 +115,7 @@ public class PaymentControllerTest {
         final PaymentGetResponse paymentGetResponse = generatePaymentGetResponse(dissolutionGetResponse.getETag(), APPLICATION_REFERENCE);
 
         when(dissolutionService.getByApplicationReference(APPLICATION_REFERENCE)).thenReturn(Optional.of(dissolutionGetResponse));
-        when(paymentService.get(dissolutionGetResponse, APPLICATION_REFERENCE)).thenReturn(paymentGetResponse);
+        when(paymentService.get(dissolutionGetResponse)).thenReturn(paymentGetResponse);
 
         mockMvc
                 .perform(

--- a/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
@@ -38,7 +38,7 @@ import static uk.gov.companieshouse.fixtures.PaymentFixtures.generatePaymentPatc
 @WebMvcTest(PaymentController.class)
 public class PaymentControllerTest {
 
-    private static final String PAYMENT_URI = "/dissolution-request/{company-number}/payment";
+    private static final String PAYMENT_URI = "/dissolution-request/{application-reference}/payment";
     private static final String APPLICATION_REFERENCE = "12345678";
 
     private static final String IDENTITY_HEADER_VALUE = "identity";

--- a/src/test/java/uk/gov/companieshouse/mapper/DissolutionResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/DissolutionResponseMapperTest.java
@@ -49,11 +49,12 @@ public class DissolutionResponseMapperTest {
     public void mapToDissolutionCreateResponse_generatesLinks() {
         final Dissolution dissolution = DissolutionFixtures.generateDissolution();
         dissolution.getCompany().setNumber("12345678");
+        dissolution.getData().getApplication().setReference("ABC123");
 
         final DissolutionCreateResponse result = mapper.mapToDissolutionCreateResponse(dissolution);
 
         assertEquals("/dissolution-request/12345678", result.getLinks().getSelf());
-        assertEquals("/dissolution-request/12345678/payment", result.getLinks().getPayment());
+        assertEquals("/dissolution-request/ABC123/payment", result.getLinks().getPayment());
     }
 
     @Test
@@ -76,7 +77,7 @@ public class DissolutionResponseMapperTest {
         assertEquals(ETAG, result.getETag());
         assertEquals(DISSOLUTION_KIND, result.getKind());
         assertEquals("/dissolution-request/12345678", result.getLinks().getSelf());
-        assertEquals("/dissolution-request/12345678/payment", result.getLinks().getPayment());
+        assertEquals("/dissolution-request/reference123/payment", result.getLinks().getPayment());
         assertEquals(STATUS, result.getApplicationStatus());
         assertEquals(REFERENCE, result.getApplicationReference());
         assertEquals(TYPE, result.getApplicationType());
@@ -155,13 +156,17 @@ public class DissolutionResponseMapperTest {
     }
 
     @Test
-    public void mapToDissolutionPatchResponse_mapsCompanyNumberToDissolutionLinks() {
-        final DissolutionPatchResponse result = mapper.mapToDissolutionPatchResponse(COMPANY_NUMBER);
-        final DissolutionLinks link = result.getLinks();
-        final String expectedSelfLink = String.format("/dissolution-request/%s", COMPANY_NUMBER);
-        final String expectedPayLink = String.format("/dissolution-request/%s/payment", COMPANY_NUMBER);
+    public void mapToDissolutionPatchResponse_mapsCompanyNumberAndReferenceToDissolutionLinks() {
+        final Dissolution dissolution = DissolutionFixtures.generateDissolution();
 
-        assertEquals(expectedSelfLink, link.getSelf());
-        assertEquals(expectedPayLink, link.getPayment());
+        dissolution.getCompany().setNumber(COMPANY_NUMBER);
+        dissolution.getData().getApplication().setReference(REFERENCE);
+
+        final DissolutionPatchResponse result = mapper.mapToDissolutionPatchResponse(dissolution);
+
+        final DissolutionLinks links = result.getLinks();
+
+        assertEquals(String.format("/dissolution-request/%s", COMPANY_NUMBER), links.getSelf());
+        assertEquals(String.format("/dissolution-request/%s/payment", REFERENCE), links.getPayment());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionGetterTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionGetterTest.java
@@ -36,11 +36,12 @@ public class DissolutionGetterTest {
     private DissolutionResponseMapper responseMapper;
 
     public static final String COMPANY_NUMBER = "12345678";
+    public static final String APPLICATION_REFERENCE = "XYZ456";
     public static final String OFFICER_ID_ONE = "abc123";
     public static final String OFFICER_ID_TWO = "def456";
 
     @Test
-    public void get_findsDissolution_mapsToDissolutionResponse_returnsGetResponse() {
+    public void getByCompanyNumber_findsDissolution_mapsToDissolutionResponse_returnsGetResponse() {
         final Dissolution dissolution = DissolutionFixtures.generateDissolution();
         final DissolutionGetResponse response = DissolutionFixtures.generateDissolutionGetResponse();
 
@@ -57,12 +58,40 @@ public class DissolutionGetterTest {
     }
 
     @Test
-    public void get_doesNotFindDissolution_returnsOptionalEmpty() {
+    public void getByCompanyNumber_doesNotFindDissolution_returnsOptionalEmpty() {
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(Optional.empty());
 
         final Optional<DissolutionGetResponse> result = getter.getByCompanyNumber(COMPANY_NUMBER);
 
         verify(repository).findByCompanyNumber(COMPANY_NUMBER);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void getByApplicationReference_findsDissolution_mapsToDissolutionResponse_returnsGetResponse() {
+        final Dissolution dissolution = DissolutionFixtures.generateDissolution();
+        final DissolutionGetResponse response = DissolutionFixtures.generateDissolutionGetResponse();
+
+        when(repository.findByDataApplicationReference(APPLICATION_REFERENCE)).thenReturn(Optional.of(dissolution));
+        when(responseMapper.mapToDissolutionGetResponse(dissolution)).thenReturn(response);
+
+        final Optional<DissolutionGetResponse> result = getter.getByApplicationReference(APPLICATION_REFERENCE);
+
+        verify(repository).findByDataApplicationReference(APPLICATION_REFERENCE);
+        verify(responseMapper).mapToDissolutionGetResponse(dissolution);
+
+        assertTrue(result.isPresent());
+        assertEquals(response, result.get());
+    }
+
+    @Test
+    public void getByApplicationReference_doesNotFindDissolution_returnsOptionalEmpty() {
+        when(repository.findByDataApplicationReference(APPLICATION_REFERENCE)).thenReturn(Optional.empty());
+
+        final Optional<DissolutionGetResponse> result = getter.getByApplicationReference(APPLICATION_REFERENCE);
+
+        verify(repository).findByDataApplicationReference(APPLICATION_REFERENCE);
 
         assertTrue(result.isEmpty());
     }

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionPatcherTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionPatcherTest.java
@@ -92,7 +92,7 @@ public class DissolutionPatcherTest {
         body.setOfficerId(OFFICER_ID);
 
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(java.util.Optional.of(dissolution));
-        when(responseMapper.mapToDissolutionPatchResponse(COMPANY_NUMBER)).thenReturn(response);
+        when(responseMapper.mapToDissolutionPatchResponse(dissolution)).thenReturn(response);
         when(approvalMapper.mapToDirectorApproval(USER_ID, IP_ADDRESS)).thenReturn(approval);
 
         patcher.addDirectorApproval(COMPANY_NUMBER, USER_ID, body);
@@ -109,12 +109,12 @@ public class DissolutionPatcherTest {
         body.setOfficerId(OFFICER_ID);
 
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(java.util.Optional.of(dissolution));
-        when(responseMapper.mapToDissolutionPatchResponse(COMPANY_NUMBER)).thenReturn(response);
+        when(responseMapper.mapToDissolutionPatchResponse(dissolution)).thenReturn(response);
         when(approvalMapper.mapToDirectorApproval(USER_ID, IP_ADDRESS)).thenReturn(approval);
 
         final DissolutionPatchResponse result = patcher.addDirectorApproval(COMPANY_NUMBER, USER_ID, body);
 
-        verify(responseMapper).mapToDissolutionPatchResponse(COMPANY_NUMBER);
+        verify(responseMapper).mapToDissolutionPatchResponse(dissolution);
         verify(repository).save(dissolutionCaptor.capture());
         verify(dissolutionEmailService).sendPendingPaymentEmail(dissolutionCaptor.capture());
 
@@ -132,7 +132,7 @@ public class DissolutionPatcherTest {
         body.setOfficerId(OFFICER_ID);
 
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(java.util.Optional.of(dissolution));
-        when(responseMapper.mapToDissolutionPatchResponse(COMPANY_NUMBER)).thenReturn(response);
+        when(responseMapper.mapToDissolutionPatchResponse(dissolution)).thenReturn(response);
         when(approvalMapper.mapToDirectorApproval(USER_ID, IP_ADDRESS)).thenReturn(approval);
         when(certificateGenerator.generateDissolutionCertificate(dissolution)).thenReturn(certificate);
 
@@ -156,7 +156,7 @@ public class DissolutionPatcherTest {
         dissolution.getData().setDirectors(directors);
 
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(java.util.Optional.of(dissolution));
-        when(responseMapper.mapToDissolutionPatchResponse(COMPANY_NUMBER)).thenReturn(response);
+        when(responseMapper.mapToDissolutionPatchResponse(dissolution)).thenReturn(response);
         when(approvalMapper.mapToDirectorApproval(USER_ID, IP_ADDRESS)).thenReturn(approval);
 
         patcher.addDirectorApproval(COMPANY_NUMBER, USER_ID, body);
@@ -186,7 +186,7 @@ public class DissolutionPatcherTest {
         dissolution.getData().setDirectors(Arrays.asList(directorOne, directorTwo));
 
         when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(java.util.Optional.of(dissolution));
-        when(responseMapper.mapToDissolutionPatchResponse(COMPANY_NUMBER)).thenReturn(response);
+        when(responseMapper.mapToDissolutionPatchResponse(dissolution)).thenReturn(response);
         when(approvalMapper.mapToDirectorApproval(USER_ID, IP_ADDRESS)).thenReturn(approval);
 
         patcher.addDirectorApproval(COMPANY_NUMBER, USER_ID, body);

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/DissolutionServiceTest.java
@@ -116,6 +116,20 @@ public class DissolutionServiceTest {
     }
 
     @Test
+    public void getByApplicationReference_returnsDissolutionGetResponse() {
+        final DissolutionGetResponse response = DissolutionFixtures.generateDissolutionGetResponse();
+
+        when(getter.getByApplicationReference(APPLICATION_REFERENCE)).thenReturn(Optional.of(response));
+
+        final Optional<DissolutionGetResponse> result = service.getByApplicationReference(APPLICATION_REFERENCE);
+
+        verify(getter).getByApplicationReference(APPLICATION_REFERENCE);
+
+        assertTrue(result.isPresent());
+        assertEquals(response, result.get());
+    }
+
+    @Test
     public void addDirectorApproval_addsDirectorApproval_returnsPatchResponse() throws DissolutionNotFoundException {
         final DissolutionPatchRequest body = generateDissolutionPatchRequest();
         body.setIpAddress(IP);

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/PaymentServiceTest.java
@@ -23,18 +23,20 @@ public class PaymentServiceTest {
     @Test
     public void get_getsPaymentUIData_returnsGetResponse() {
         String companyNumber = "12345678";
+        String applicationReference = "ABC123";
 
         DissolutionGetResponse dissolutionGetResponse = generateDissolutionGetResponse();
         dissolutionGetResponse.setCompanyNumber(companyNumber);
+        dissolutionGetResponse.setApplicationReference(applicationReference);
         dissolutionGetResponse.setETag("WATERMELONSAREGREAT12345678THEYREALLYARE");
         dissolutionGetResponse.setApplicationType(ApplicationType.DS01);
 
-        final PaymentGetResponse result = service.get(dissolutionGetResponse, companyNumber);
+        final PaymentGetResponse result = service.get(dissolutionGetResponse);
 
         assertEquals(dissolutionGetResponse.getETag(), result.getETag());
         assertEquals(PAYMENT_KIND, result.getKind());
         assertEquals(companyNumber, result.getCompanyNumber());
-        assertEquals("/dissolution-request/" + companyNumber + "/payment", result.getLinks().getSelf());
+        assertEquals("/dissolution-request/" + applicationReference + "/payment", result.getLinks().getSelf());
         assertEquals("/dissolution-request/" + companyNumber, result.getLinks().getDissolutionRequest());
         assertEquals(PAYMENT_DESCRIPTION, result.getItems().get(0).getDescription());
         assertEquals(PAYMENT_DESCRIPTION_IDENTIFIER, result.getItems().get(0).getDescriptionIdentifier());
@@ -55,7 +57,7 @@ public class PaymentServiceTest {
         dissolutionGetResponse.setETag("WATERMELONSAREGREAT12345678THEYREALLYARE");
         dissolutionGetResponse.setApplicationType(ApplicationType.DS01);
 
-        final PaymentGetResponse result = service.get(dissolutionGetResponse, companyNumber);
+        final PaymentGetResponse result = service.get(dissolutionGetResponse);
 
         assertEquals(ApplicationType.DS01, result.getItems().get(0).getProductType());
     }
@@ -69,7 +71,7 @@ public class PaymentServiceTest {
         dissolutionGetResponse.setETag("WATERMELONSAREGREAT12345678THEYREALLYARE");
         dissolutionGetResponse.setApplicationType(ApplicationType.LLDS01);
 
-        final PaymentGetResponse result = service.get(dissolutionGetResponse, companyNumber);
+        final PaymentGetResponse result = service.get(dissolutionGetResponse);
 
         System.out.println(result.getItems().get(0).getProductType());
         assertEquals(ApplicationType.LLDS01, result.getItems().get(0).getProductType());

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/PaymentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/PaymentServiceTest.java
@@ -4,12 +4,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.model.dto.dissolution.DissolutionGetResponse;
 import uk.gov.companieshouse.model.dto.payment.PaymentGetResponse;
 import uk.gov.companieshouse.model.enums.ApplicationType;
 import uk.gov.companieshouse.service.payment.PaymentService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolutionGetResponse;
 import static uk.gov.companieshouse.model.Constants.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -20,13 +22,16 @@ public class PaymentServiceTest {
 
     @Test
     public void get_getsPaymentUIData_returnsGetResponse() {
-        final String companyNumber = "12345678";
-        final String eTag = "WATERMELONSAREGREAT12345678THEYREALLYARE";
-        final ApplicationType applicationType = ApplicationType.DS01;
+        String companyNumber = "12345678";
 
-        final PaymentGetResponse result = service.get(eTag, applicationType, companyNumber);
+        DissolutionGetResponse dissolutionGetResponse = generateDissolutionGetResponse();
+        dissolutionGetResponse.setCompanyNumber(companyNumber);
+        dissolutionGetResponse.setETag("WATERMELONSAREGREAT12345678THEYREALLYARE");
+        dissolutionGetResponse.setApplicationType(ApplicationType.DS01);
 
-        assertEquals(eTag, result.getETag());
+        final PaymentGetResponse result = service.get(dissolutionGetResponse, companyNumber);
+
+        assertEquals(dissolutionGetResponse.getETag(), result.getETag());
         assertEquals(PAYMENT_KIND, result.getKind());
         assertEquals(companyNumber, result.getCompanyNumber());
         assertEquals("/dissolution-request/" + companyNumber + "/payment", result.getLinks().getSelf());
@@ -43,22 +48,28 @@ public class PaymentServiceTest {
 
     @Test
     public void get_getsPaymentUIData_returnsProperCodeForDS01() {
-        final String companyNumber = "12345678";
-        final String eTag = "WATERMELONSAREGREAT12345678THEYREALLYARE";
-        final ApplicationType applicationType = ApplicationType.DS01;
+        String companyNumber = "12345678";
 
-        final PaymentGetResponse result = service.get(eTag, applicationType, companyNumber);
+        DissolutionGetResponse dissolutionGetResponse = generateDissolutionGetResponse();
+        dissolutionGetResponse.setCompanyNumber(companyNumber);
+        dissolutionGetResponse.setETag("WATERMELONSAREGREAT12345678THEYREALLYARE");
+        dissolutionGetResponse.setApplicationType(ApplicationType.DS01);
+
+        final PaymentGetResponse result = service.get(dissolutionGetResponse, companyNumber);
 
         assertEquals(ApplicationType.DS01, result.getItems().get(0).getProductType());
     }
 
     @Test
     public void get_getsPaymentUIData_returnsProperCodeForLLDS01() {
-        final String companyNumber = "12345678";
-        final String eTag = "WATERMELONSAREGREAT12345678THEYREALLYARE";
-        final ApplicationType applicationType = ApplicationType.LLDS01;
+        String companyNumber = "12345678";
 
-        final PaymentGetResponse result = service.get(eTag, applicationType, companyNumber);
+        DissolutionGetResponse dissolutionGetResponse = generateDissolutionGetResponse();
+        dissolutionGetResponse.setCompanyNumber(companyNumber);
+        dissolutionGetResponse.setETag("WATERMELONSAREGREAT12345678THEYREALLYARE");
+        dissolutionGetResponse.setApplicationType(ApplicationType.LLDS01);
+
+        final PaymentGetResponse result = service.get(dissolutionGetResponse, companyNumber);
 
         System.out.println(result.getItems().get(0).getProductType());
         assertEquals(ApplicationType.LLDS01, result.getItems().get(0).getProductType());


### PR DESCRIPTION
## Description
Due to refunds reconciliation being async, the dissolution may be marked as inactive before the refund is fully reconciled. This causes a 404 on the dissolution api because the company number does not have an active dissolution.

By using the reference, we no longer have to rely on the active flag as it is always unique.

## Jira Ticket

Please add link to Jira ticket

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [ ] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [x] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description
