### PR TITLE
New endpoint in dissolution-api for resend signatory email functionality 

### DIFF
--- a/src/main/java/uk/gov/companieshouse/controller/ResendEmailController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/ResendEmailController.java
@@ -1,0 +1,48 @@
+package uk.gov.companieshouse.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import uk.gov.companieshouse.exception.DissolutionNotFoundException;
+import uk.gov.companieshouse.exception.NotFoundException;
+import uk.gov.companieshouse.model.db.dissolution.Dissolution;
+import uk.gov.companieshouse.repository.DissolutionRepository;
+import uk.gov.companieshouse.service.dissolution.DissolutionEmailService;
+
+@RestController
+@RequestMapping("/dissolution-request/{company-number}/resend-email/{email-address}")
+public class ResendEmailController {
+
+    private final DissolutionEmailService emailService;
+    private final DissolutionRepository repository;
+
+    public ResendEmailController(
+            DissolutionEmailService emailService,
+            DissolutionRepository repository) {
+
+        this.emailService = emailService;
+        this.repository = repository;
+    }
+
+    @Operation(summary = "Resend signatory email", tags = "Dissolution")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Email resent"),
+            @ApiResponse(responseCode = "404", description = "Dissolution not found")
+    })
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    public void resendSignatoryEmail(
+            @PathVariable("company-number") final String companyNumber,
+            @PathVariable("email-address") final String emailAddress) {
+
+        try {
+            final Dissolution dissolution = repository.findByCompanyNumber(companyNumber).orElseThrow(DissolutionNotFoundException::new);
+            emailService.notifySignatoryToSign(dissolution, emailAddress);
+        } catch(Exception e) {
+            throw new NotFoundException();
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/controller/ResendEmailController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/ResendEmailController.java
@@ -16,14 +16,14 @@ import uk.gov.companieshouse.service.dissolution.DissolutionEmailService;
 public class ResendEmailController {
 
     private final DissolutionEmailService emailService;
-    private final DissolutionRepository repository;
+    private final DissolutionRepository dissolutionRepository;
 
     public ResendEmailController(
             DissolutionEmailService emailService,
-            DissolutionRepository repository) {
+            DissolutionRepository dissolutionRepository) {
 
         this.emailService = emailService;
-        this.repository = repository;
+        this.dissolutionRepository = dissolutionRepository;
     }
 
     @Operation(summary = "Resend signatory email", tags = "Dissolution")
@@ -39,7 +39,7 @@ public class ResendEmailController {
             @PathVariable("email-address") final String emailAddress) {
 
         try {
-            final Dissolution dissolution = repository.findByCompanyNumber(companyNumber).orElseThrow(DissolutionNotFoundException::new);
+            final Dissolution dissolution = dissolutionRepository.findByCompanyNumber(companyNumber).orElseThrow(DissolutionNotFoundException::new);
             emailService.notifySignatoryToSign(dissolution, emailAddress);
         } catch(Exception e) {
             throw new NotFoundException();

--- a/src/test/java/uk/gov/companieshouse/controller/ResendEmailControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/ResendEmailControllerTest.java
@@ -1,0 +1,72 @@
+package uk.gov.companieshouse.controller;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.companieshouse.api.util.security.EricConstants;
+import uk.gov.companieshouse.api.util.security.Permission;
+import uk.gov.companieshouse.model.db.dissolution.Dissolution;
+import uk.gov.companieshouse.repository.DissolutionRepository;
+import uk.gov.companieshouse.service.dissolution.DissolutionEmailService;
+import uk.gov.companieshouse.service.dissolution.chips.DissolutionChipsService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(ResendEmailController.class)
+public class ResendEmailControllerTest {
+
+    private static final String EMAIL_URI = "/dissolution-request/{company-number}/resend-email/{email-address}";
+    private static final String COMPANY_NUMBER = "12345";
+    private static final String EMAIL_ADDRESS = "yaboi@mail.com";
+    private static final String USER_ID = "1234";
+    private static final String AUTHORISED_USER_HEADER = "ERIC-Authorised-User";
+
+    @MockBean
+    private DissolutionChipsService service;
+
+    @MockBean
+    private DissolutionEmailService emailService;
+
+    @MockBean
+    private DissolutionRepository repository;
+
+    @MockBean
+    private Dissolution dissolution;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void testEmailResendIsAuthorisedReturnsOk() throws Exception {
+        when(repository.findByCompanyNumber(COMPANY_NUMBER)).thenReturn(java.util.Optional.ofNullable(dissolution));
+        mockMvc.perform(post(EMAIL_URI,COMPANY_NUMBER,EMAIL_ADDRESS).headers(createHttpHeaders()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testEmailResendIsNotAuthorisedReturns401() throws Exception {
+        mockMvc.perform(post(EMAIL_URI,COMPANY_NUMBER,EMAIL_ADDRESS).headers(createHttpHeaders()))
+                .andExpect(status().isNotFound());
+    }
+
+    private HttpHeaders createHttpHeaders() {
+        final HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(EricConstants.ERIC_IDENTITY, USER_ID);
+        httpHeaders.add(AUTHORISED_USER_HEADER, EMAIL_ADDRESS);
+        httpHeaders.add(EricConstants.ERIC_AUTHORISED_TOKEN_PERMISSIONS, String.format(
+                "%s=%s %s=%s",
+                Permission.Key.COMPANY_NUMBER.toString(), COMPANY_NUMBER,
+                Permission.Key.COMPANY_STATUS, Permission.Value.UPDATE
+        ));
+
+        return httpHeaders;
+    }
+}


### PR DESCRIPTION
## Description

Creation of new endpoint in dissolution api repo to be called from dissolution web to resend email out for signatories to sign.
Dependant on Dissolution-web changes from: https://github.com/companieshouse/dissolution-web/pull/335

## Jira Ticket

BI-6211, BI-6212

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [x] Pulled latest master into feature branch
- [x] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [x] If your pull request depends on any other, please link them in the description
