### PR TITLE
Stop payment email being sent out for single director companies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Versions -->
-        <version.spring.boot>2.4.0</version.spring.boot>
+        <version.spring.boot>2.4.3</version.spring.boot>
         <version.springdoc.openapi>1.4.8</version.springdoc.openapi>
         <api-helper-java.version>1.4.2</api-helper-java.version>
         <api-security-java.version>0.2.11</api-security-java.version>
@@ -46,6 +46,22 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-core</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.1.59.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.59.Final</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionPatcher.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionPatcher.java
@@ -18,6 +18,8 @@ import uk.gov.companieshouse.model.enums.ApplicationStatus;
 import uk.gov.companieshouse.repository.DissolutionRepository;
 import uk.gov.companieshouse.service.dissolution.certificate.DissolutionCertificateGenerator;
 
+import java.util.List;
+
 @Service
 public class DissolutionPatcher {
 
@@ -63,9 +65,12 @@ public class DissolutionPatcher {
     }
 
     private void handleFinalApproval(Dissolution dissolution) {
+        final List<DissolutionDirector> directors = dissolution.getData().getDirectors();
         setDissolutionStatus(dissolution, ApplicationStatus.PENDING_PAYMENT);
         dissolution.setCertificate(this.certificateGenerator.generateDissolutionCertificate(dissolution));
-        dissolutionEmailService.sendPendingPaymentEmail(dissolution);
+        if (directors.size()>1) {
+            dissolutionEmailService.sendPendingPaymentEmail(dissolution);
+        }
     }
 
     public void handlePayment(PaymentPatchRequest body, String applicationReference) throws DissolutionNotFoundException {


### PR DESCRIPTION
## Description

Stop payment email being sent out when processing dissolution of single director companies.
Update spring boot to version 2.4.3,
Force correct version of Netty that were missed in other dependancies,
Resolving tomcat-embed and Netty vulnerabilities.

## Jira Ticket

BI-6898, BI-6412

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [x] Pulled latest master into feature branch
- [x] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [x] If your pull request depends on any other, please link them in the description
