### PR TITLE
Add resend email path to the authentication list

### DIFF
--- a/src/main/java/uk/gov/companieshouse/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/config/SecurityConfig.java
@@ -17,7 +17,8 @@ public class SecurityConfig implements WebMvcConfigurer {
     private static final String[] API_KEY_PERMISSION_AUTH_INCLUDE_LIST = {
             "/dissolution-request/{application-reference}/payment",
             "/dissolution-request/submit",
-            "/dissolution-request/response"
+            "/dissolution-request/response",
+            "/dissolution-request/{company-number}/resend-email/{email-address}"
     };
 
     private static final String[] TOKEN_PERMISSION_AUTH_EXCLUDE_LIST = ArrayUtils.addAll(


### PR DESCRIPTION
## Description

Needed to include the resend email path to authentication list so that it can be authenticated to respond to dissolution-web call.

## Jira Ticket

[BI-6211](https://companieshouse.atlassian.net/browse/BI-6211)

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [x] Pulled latest master into feature branch
- [x] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description
