### PR TITLE
Add support email for alert of application failure

### DIFF
--- a/src/main/java/uk/gov/companieshouse/mapper/email/DissolutionEmailMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/email/DissolutionEmailMapper.java
@@ -101,7 +101,7 @@ public class DissolutionEmailMapper {
     public SupportNotificationEmailData mapToSupportNotificationEmailData(Dissolution dissolution) {
         SupportNotificationEmailData supportNotificationEmailData = new SupportNotificationEmailData();
 
-        supportNotificationEmailData.setTo("asaleem@companieshouse.gov.uk");
+        supportNotificationEmailData.setTo(environmentConfig.getChsSupportEmail());
         supportNotificationEmailData.setSubject(DISSOLUTION_SUBMISSION_ALERT);
         supportNotificationEmailData.setDissolutionReferenceNumber(dissolution.getData().getApplication().getReference());
         supportNotificationEmailData.setCompanyNumber(dissolution.getCompany().getNumber());


### PR DESCRIPTION
Add support email to rebel1 env to alert internal support team of application failure. 
Reverting temporary email used for testing purposes from commit: https://github.com/companieshouse/dissolution-api/commit/72f317208e2fa88cf3a2d081aee5202d61f99c83


BI-5893 https://companieshouse.atlassian.net/browse/BI-5893

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [x] Pulled latest master into feature branch
- [x] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description
