### PR TITLE
Email to support to trigger on Chips submission failure

### DIFF
--- a/src/main/java/uk/gov/companieshouse/service/dissolution/chips/ChipsSubmitter.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/chips/ChipsSubmitter.java
@@ -84,7 +84,6 @@ public class ChipsSubmitter {
             handleFailedSubmission(submission, dissolution);
         }
 
-        dissolutionService.sendFailedSubmissionNotificationEmail(dissolution);
         repository.save(dissolution);
     }
 
@@ -94,6 +93,7 @@ public class ChipsSubmitter {
         if (submission.getRetryCounter() == config.getChipsRetryLimit()) {
             logger.error(String.format("Marking dissolution as failed for company %s", dissolution.getCompany().getNumber()));
             submission.setStatus(SubmissionStatus.FAILED);
+            dissolutionService.sendFailedSubmissionNotificationEmail(dissolution);
         }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/service/dissolution/chips/ChipsSubmitterTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/dissolution/chips/ChipsSubmitterTest.java
@@ -94,7 +94,7 @@ public class ChipsSubmitterTest {
         submitter.submitDissolutionToChips(dissolution);
 
         verify(repository).save(dissolutionCaptor.capture());
-        verify(dissolutionService, times(1)).sendFailedSubmissionNotificationEmail(dissolution);
+        verify(dissolutionService, times(0)).sendFailedSubmissionNotificationEmail(dissolution);
 
         final Dissolution updatedDissolution = dissolutionCaptor.getValue();
 
@@ -116,7 +116,7 @@ public class ChipsSubmitterTest {
         submitter.submitDissolutionToChips(dissolution);
 
         verify(repository).save(dissolutionCaptor.capture());
-        verify(dissolutionService, times(1)).sendFailedSubmissionNotificationEmail(dissolution);
+        verify(dissolutionService, times(0)).sendFailedSubmissionNotificationEmail(dissolution);
 
         final Dissolution updatedDissolution = dissolutionCaptor.getValue();
 


### PR DESCRIPTION
Move function for emailing support to trigger only on chips submission failure previously triggered regardless of test failure for testing purposes. See comments on jira ticket for more information

BI-5893 https://companieshouse.atlassian.net/browse/BI-5893

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [x] API (Karate) tests passing
- [x] Pulled latest master into feature branch
- [x] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description
