### PR TITLE
Suppress netty-tcnative-classes false positive security issue

### DIFF
--- a/suppressed-security-checks.xml
+++ b/suppressed-security-checks.xml
@@ -72,4 +72,23 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
         <cve>CVE-2021-42340</cve>
     </suppress>
+        <suppress>
+        <notes><![CDATA[
+            file name: netty-tcnative-classes-2.0.46.Final.jar
+            JIRA ticket: TBC
+            Note: This is a false positive security issue see https://github.com/jeremylong/DependencyCheck/issues/3865
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-tcnative\-classes@.*$</packageUrl>
+        <cve>CVE-2021-43797</cve>
+        <cve>CVE-2019-16869</cve>
+        <cve>CVE-2015-2156</cve>
+        <cve>CVE-2021-37136</cve>
+        <cve>CVE-2014-3488</cve>
+        <cve>CVE-2021-37137</cve>
+        <cve>CVE-2019-20445</cve>
+        <cve>CVE-2019-20444</cve>
+        <cve>CVE-2021-21295</cve>
+        <cve>CVE-2021-21409</cve>
+        <cve>CVE-2021-21290</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Description

Security check is failing on the netty-tcnative-classes dependency. This is a false positive as the regex used by the security software does not account for this dependency. For more info see open issue: https://github.com/jeremylong/DependencyCheck/issues/3865

## Jira Ticket

DEBT-1408

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [x] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [x] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description
