### PR TITLE
Revert "Bump de.flapdoodle.embed.mongo from 3.0.0 to 3.4.8"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <version>3.4.8</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Reverts companieshouse/dissolution-api#607