### PR TITLE
Payment status

### DIFF
--- a/src/main/java/uk/gov/companieshouse/client/PaymentsClient.java
+++ b/src/main/java/uk/gov/companieshouse/client/PaymentsClient.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import uk.gov.companieshouse.config.PaymentsConfig;
+import uk.gov.companieshouse.model.dto.payment.PaymentDetailsResponse;
 import uk.gov.companieshouse.model.dto.payment.RefundRequest;
 import uk.gov.companieshouse.model.dto.payment.RefundResponse;
 
@@ -14,6 +15,7 @@ import static uk.gov.companieshouse.model.Constants.*;
 public class PaymentsClient {
 
     private static final String REFUNDS_URI = "/payments/{paymentReference}/refunds";
+    private static final String PAYMENT_DETAILS_URI = "/private/payments/{paymentReference}/payment-details";
 
     private final PaymentsConfig config;
 
@@ -34,5 +36,17 @@ public class PaymentsClient {
             .retrieve()
             .bodyToMono(RefundResponse.class)
             .block();
+    }
+
+    public PaymentDetailsResponse getPaymentDetails(String paymentReference) {
+        return WebClient
+                .create(config.getPaymentsHost())
+                .get()
+                .uri(PAYMENT_DETAILS_URI, paymentReference)
+                .header(HEADER_AUTHORIZATION, config.getApiKey())
+                .header(HEADER_ACCEPT, CONTENT_TYPE_JSON)
+                .retrieve()
+                .bodyToMono(PaymentDetailsResponse.class)
+                .block();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/controller/DissolutionController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/DissolutionController.java
@@ -27,9 +27,7 @@ import uk.gov.companieshouse.model.dto.dissolution.DissolutionCreateResponse;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionGetResponse;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchRequest;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchResponse;
-import uk.gov.companieshouse.model.dto.payment.PaymentDetailsResponse;
 import uk.gov.companieshouse.model.enums.ApplicationStatus;
-import uk.gov.companieshouse.model.enums.PaymentStatus;
 import uk.gov.companieshouse.service.CompanyOfficerService;
 import uk.gov.companieshouse.service.dissolution.DissolutionService;
 import uk.gov.companieshouse.service.dissolution.validator.DissolutionValidator;
@@ -111,14 +109,13 @@ public class DissolutionController {
         DissolutionGetResponse dissolutionGetResponse = dissolutionService
                 .getByCompanyNumber(companyNumber)
                 .orElseThrow(NotFoundException::new);
-
-        if (dissolutionGetResponse.getApplicationStatus().equals(ApplicationStatus.PENDING_PAYMENT)) {
+        String paymentRef = dissolutionGetResponse.getPaymentReference();
+        if ( paymentRef != null && !paymentRef.equals("") && dissolutionGetResponse.getApplicationStatus().equals(ApplicationStatus.PENDING_PAYMENT)) {
             // payment could be complete, we need to get up-to-date status to be sure
             String paymentStatus = paymentService.getPaymentStatus(dissolutionGetResponse.getPaymentReference());
-            if (paymentStatus.equals(PaymentStatus.PAID)) {
+            if (paymentStatus.equals("accepted")) {
                 dissolutionGetResponse.setApplicationStatus(ApplicationStatus.PAID);
             }
-
         }
 
         return dissolutionGetResponse;

--- a/src/main/java/uk/gov/companieshouse/controller/DissolutionController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/DissolutionController.java
@@ -27,9 +27,13 @@ import uk.gov.companieshouse.model.dto.dissolution.DissolutionCreateResponse;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionGetResponse;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchRequest;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchResponse;
+import uk.gov.companieshouse.model.dto.payment.PaymentDetailsResponse;
+import uk.gov.companieshouse.model.enums.ApplicationStatus;
+import uk.gov.companieshouse.model.enums.PaymentStatus;
 import uk.gov.companieshouse.service.CompanyOfficerService;
 import uk.gov.companieshouse.service.dissolution.DissolutionService;
 import uk.gov.companieshouse.service.dissolution.validator.DissolutionValidator;
+import uk.gov.companieshouse.service.payment.PaymentService;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -46,16 +50,19 @@ public class DissolutionController {
     private final DissolutionValidator dissolutionValidator;
     private final CompanyProfileClient companyProfileClient;
     private final CompanyOfficerService companyOfficerService;
+    private final PaymentService paymentService;
 
     public DissolutionController(
             DissolutionService dissolutionService,
             DissolutionValidator dissolutionValidator,
             CompanyProfileClient companyProfileClient,
-            CompanyOfficerService companyOfficerService) {
+            CompanyOfficerService companyOfficerService,
+            PaymentService paymentService) {
         this.dissolutionService = dissolutionService;
         this.dissolutionValidator = dissolutionValidator;
         this.companyProfileClient = companyProfileClient;
         this.companyOfficerService = companyOfficerService;
+        this.paymentService = paymentService;
     }
 
     @Operation(summary = "Create Dissolution Request", tags = "Dissolution")
@@ -101,9 +108,20 @@ public class DissolutionController {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public DissolutionGetResponse getDissolutionApplication(@PathVariable("company-number") final String companyNumber) {
-        return dissolutionService
+        DissolutionGetResponse dissolutionGetResponse = dissolutionService
                 .getByCompanyNumber(companyNumber)
                 .orElseThrow(NotFoundException::new);
+
+        if (dissolutionGetResponse.getApplicationStatus().equals(ApplicationStatus.PENDING_PAYMENT)) {
+            // payment could be complete, we need to get up-to-date status to be sure
+            String paymentStatus = paymentService.getPaymentStatus(dissolutionGetResponse.getPaymentReference());
+            if (paymentStatus.equals(PaymentStatus.PAID)) {
+                dissolutionGetResponse.setApplicationStatus(ApplicationStatus.PAID);
+            }
+
+        }
+
+        return dissolutionGetResponse;
     }
 
     @Operation(summary = "Patch Dissolution Application", tags = "Dissolution")

--- a/src/main/java/uk/gov/companieshouse/controller/PaymentController.java
+++ b/src/main/java/uk/gov/companieshouse/controller/PaymentController.java
@@ -95,6 +95,12 @@ public class PaymentController {
             } catch (DissolutionNotFoundException e) {
                 throw new NotFoundException();
             }
+        } else {
+            try {
+                dissolutionService.setPaymentReference(body.getPaymentReference(), applicationReference);
+            } catch (DissolutionNotFoundException e) {
+                throw new NotFoundException();
+            }
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/mapper/DissolutionResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/DissolutionResponseMapper.java
@@ -46,6 +46,7 @@ public class DissolutionResponseMapper extends ResponseMapper {
         response.setCreatedAt(Timestamp.valueOf(dissolution.getCreatedBy().getDateTime()));
         response.setCreatedBy(dissolution.getCreatedBy().getEmail());
         response.setDirectors(mapToDissolutionGetDirectors(dissolution.getData().getDirectors()));
+        response.setPaymentReference(dissolution.getPaymentInformation().getReference());
 
         Optional
                 .ofNullable(dissolution.getCertificate())

--- a/src/main/java/uk/gov/companieshouse/mapper/DissolutionResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/DissolutionResponseMapper.java
@@ -46,12 +46,16 @@ public class DissolutionResponseMapper extends ResponseMapper {
         response.setCreatedAt(Timestamp.valueOf(dissolution.getCreatedBy().getDateTime()));
         response.setCreatedBy(dissolution.getCreatedBy().getEmail());
         response.setDirectors(mapToDissolutionGetDirectors(dissolution.getData().getDirectors()));
-        response.setPaymentReference(dissolution.getPaymentInformation().getReference());
 
         Optional
                 .ofNullable(dissolution.getCertificate())
                 .ifPresent(certificate -> setCertificateDetails(response, certificate));
 
+        if (dissolution.getPaymentInformation() != null) {
+            Optional
+                    .ofNullable(dissolution.getPaymentInformation().getReference())
+                    .ifPresent(paymentReference -> setPaymentReference(response, paymentReference));
+        }
         return response;
     }
 
@@ -88,5 +92,9 @@ public class DissolutionResponseMapper extends ResponseMapper {
     private void setCertificateDetails(DissolutionGetResponse response, DissolutionCertificate certificate) {
         response.setCertificateBucket(certificate.getBucket());
         response.setCertificateKey(certificate.getKey());
+    }
+
+    private void setPaymentReference(DissolutionGetResponse response, String paymentReference) {
+        response.setPaymentReference(paymentReference);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/mapper/PaymentInformationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/PaymentInformationMapper.java
@@ -23,4 +23,11 @@ public class PaymentInformationMapper {
 
         return paymentInformation;
     }
+
+    public PaymentInformation mapPaymentReference(String paymentReference) {
+        PaymentInformation paymentInformation = new PaymentInformation();
+        paymentInformation.setReference(paymentReference);
+
+        return paymentInformation;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/model/dto/dissolution/DissolutionGetResponse.java
+++ b/src/main/java/uk/gov/companieshouse/model/dto/dissolution/DissolutionGetResponse.java
@@ -44,6 +44,9 @@ public class DissolutionGetResponse {
 
     private List<DissolutionGetDirector> directors;
 
+    @JsonProperty("payment_reference")
+    private String paymentReference;
+
     @JsonProperty("ETag")
     public String getETag() {
         return eTag;
@@ -147,5 +150,13 @@ public class DissolutionGetResponse {
 
     public void setCertificateKey(String certificateKey) {
         this.certificateKey = certificateKey;
+    }
+
+    public String getPaymentReference() {
+        return paymentReference;
+    }
+
+    public void setPaymentReference(String paymentReference) {
+        this.paymentReference = paymentReference;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/model/dto/payment/PaymentDetailsResponse.java
+++ b/src/main/java/uk/gov/companieshouse/model/dto/payment/PaymentDetailsResponse.java
@@ -1,0 +1,61 @@
+package uk.gov.companieshouse.model.dto.payment;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PaymentDetailsResponse {
+    @JsonProperty("card_type")
+    private String cardType;
+
+    @JsonProperty("external_payment_id")
+    private String externalPaymentID;
+
+    @JsonProperty("transaction_date")
+    private String transactionDate;
+
+    @JsonProperty("payment_status")
+    private String paymentStatus;
+
+    @JsonProperty("provider_id")
+    private String providerID;
+
+
+    public String getCardType() {
+        return cardType;
+    }
+
+    public void setCardType(String cardType) {
+        this.cardType = cardType;
+    }
+
+    public String getExternalPaymentID() {
+        return externalPaymentID;
+    }
+
+    public void setExternalPaymentID(String externalPaymentID) {
+        this.externalPaymentID = externalPaymentID;
+    }
+
+    public String getTransactionDate() {
+        return transactionDate;
+    }
+
+    public void setTransactionDate(String transactionDate) {
+        this.transactionDate = transactionDate;
+    }
+
+    public String getPaymentStatus() {
+        return paymentStatus;
+    }
+
+    public void setPaymentStatus(String paymentStatus) {
+        this.paymentStatus = paymentStatus;
+    }
+
+    public String getProviderID() {
+        return providerID;
+    }
+
+    public void setProviderID(String providerID) {
+        this.providerID = providerID;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionService.java
+++ b/src/main/java/uk/gov/companieshouse/service/dissolution/DissolutionService.java
@@ -44,6 +44,10 @@ public class DissolutionService {
         patcher.handlePayment(body, applicationReference);
     }
 
+    public void setPaymentReference(String paymentReference, String applicationReference) throws DissolutionNotFoundException {
+        patcher.setPaymentReference(paymentReference, applicationReference);
+    }
+
     public boolean doesDissolutionRequestExistForCompanyByCompanyNumber(String companyNumber) {
         return repository.findByCompanyNumber(companyNumber).isPresent();
     }

--- a/src/main/java/uk/gov/companieshouse/service/payment/PaymentService.java
+++ b/src/main/java/uk/gov/companieshouse/service/payment/PaymentService.java
@@ -1,12 +1,13 @@
 package uk.gov.companieshouse.service.payment;
 
 import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.client.PaymentsClient;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionGetResponse;
 import uk.gov.companieshouse.model.dto.payment.PaymentDescriptionValues;
+import uk.gov.companieshouse.model.dto.payment.PaymentDetailsResponse;
 import uk.gov.companieshouse.model.dto.payment.PaymentGetResponse;
 import uk.gov.companieshouse.model.dto.payment.PaymentItem;
 import uk.gov.companieshouse.model.dto.payment.PaymentLinks;
-import uk.gov.companieshouse.model.enums.ApplicationType;
 
 import java.util.List;
 
@@ -14,6 +15,13 @@ import static uk.gov.companieshouse.model.Constants.*;
 
 @Service
 public class PaymentService {
+    private final PaymentsClient paymentsClient;
+
+    public PaymentService(
+            PaymentsClient paymentsClient
+    ) {
+        this.paymentsClient = paymentsClient;
+    }
 
     public PaymentGetResponse get(DissolutionGetResponse dissolutionInfo) {
         PaymentGetResponse response = new PaymentGetResponse();
@@ -31,6 +39,11 @@ public class PaymentService {
 
         return response;
     }
+    public String getPaymentStatus(String paymentReference) {
+        PaymentDetailsResponse paymentDetailsResponse = paymentsClient.getPaymentDetails(paymentReference);
+
+        return paymentDetailsResponse.getPaymentStatus();
+    }
 
     private PaymentItem createPaymentItem(DissolutionGetResponse dissolutionInfo) {
         PaymentItem item = new PaymentItem();
@@ -47,4 +60,5 @@ public class PaymentService {
 
         return item;
     }
+
 }


### PR DESCRIPTION
For dissolution submissions with pending-payment status, make a call to Payments API to get correct up-to-date status, as payment could be complete.

Also add functionality to store Payment Reference in dissolution when creating payment, as this is needed to retrieve the payment later in the journey.

BI-12788

