### PR TITLE
fix: build issue due to dependency version causing error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <api-helper-java.version>3.0.0</api-helper-java.version>
         <api-security-java.version>2.0.1</api-security-java.version>
         <api-sdk-java.version>6.0.17</api-sdk-java.version>
-        <private-api-sdk-java.version>4.0.103</private-api-sdk-java.version>
+        <private-api-sdk-java.version>3.0.0</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.0</api-sdk-manager-java-library.version>
         <structured-logging.version>3.0.0</structured-logging.version>
         <commons-lang3.version>3.14.0</commons-lang3.version>


### PR DESCRIPTION
New version of private-api-sdk-java was causing issues with tomcat starting