### PR TITLE
Reduce logging verbosity by removing global config

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,11 +49,6 @@ kafka:
     uri:
       email-send: ${EMAIL_SCHEMA_URI}
 
-logging:
-  level:
-    root: ${LOGLEVEL}
-  namespace: dissolution-api
-
 payments:
   url: ${PAYMENTS_API_URL}
 


### PR DESCRIPTION
dissolution-api logging is very verbose. The thought is that this block is not usually needed in a CH service and removing it will make our logs more readable.


## Jira Ticket
[CC-1818](https://companieshouse.atlassian.net/browse/CC-1818)

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide



[CC-1818]: https://companieshouse.atlassian.net/browse/CC-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ