### PR TITLE
ASM-1618 Downgrade ECS module versions for secrets and ecs-service to 1.0.350.

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.370"
+  source = "git@github.com:companieshouse/terraform-modules/aws/ecs/secrets?ref=1.0.350"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
@@ -28,7 +28,7 @@ module "secrets" {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.370"
+  source = "git@github.com:companieshouse/terraform-modules/aws/ecs/ecs-service?ref=1.0.350"
 
   # Environmental configuration
   environment             = var.environment


### PR DESCRIPTION
## Description

Had to revert terraform-modules version as subsequent versions present a breaking change as the `secrets` element has been removed.

## Jira Ticket

ASM-1618

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [ ] Branch named {feature|hotfix|task}/{S4-*}
- [ ] Commit messages are meaningful
- [ ] Manually tested
- [ ] All unit tests passing
- [ ] API (Karate) tests passing
- [ ] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description
