### PR TITLE
ASM-1862 Jackson 3 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <api-helper-java.version>3.0.4</api-helper-java.version>
         <api-security-java.version>2.0.26</api-security-java.version>
         <api-sdk-java.version>6.6.15</api-sdk-java.version>
-        <private-api-sdk-java.version>4.0.494</private-api-sdk-java.version>
+        <private-api-sdk-java.version>5.0.0</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
         <structured-logging.version>3.0.54</structured-logging.version>
         <environment-reader-library.version>3.0.5</environment-reader-library.version>
@@ -107,14 +107,6 @@
 
     <dependencyManagement>
         <dependencies>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
 
             <dependency>
                 <groupId>tools.jackson.core</groupId>
@@ -291,6 +283,22 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>tools.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.21</version>
+        </dependency>
+
+        <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>api-sdk-java</artifactId>
             <version>${api-sdk-java.version}</version>
@@ -370,21 +378,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-xml</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.21</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <!-- Companies House Internal Dependencies -->
         <api-helper-java.version>3.0.4</api-helper-java.version>
         <api-security-java.version>2.0.26</api-security-java.version>
-        <api-sdk-java.version>6.6.15</api-sdk-java.version>
+        <api-sdk-java.version>6.6.16</api-sdk-java.version>
         <private-api-sdk-java.version>5.0.0</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.19</api-sdk-manager-java-library.version>
         <structured-logging.version>3.0.54</structured-logging.version>
@@ -62,19 +62,17 @@
         <!-- Source: https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients -->
         <kafka-clients.version>4.2.0</kafka-clients.version>
         <!-- Source: https://mvnrepository.com/artifact/software.amazon.awssdk/bom -->
-        <aws-java-sdk.version>2.42.30</aws-java-sdk.version>
+        <aws-java-sdk.version>2.42.36</aws-java-sdk.version>
         <!-- Source: https://mvnrepository.com/artifact/io.netty/netty-all -->
         <netty.version>4.2.12.Final</netty.version>
         <!-- Source: https://mvnrepository.com/artifact/io.projectreactor.netty/reactor-netty-core -->
-        <reactor-netty-core.version>1.3.4</reactor-netty-core.version>
+        <reactor-netty-core.version>1.3.5</reactor-netty-core.version>
         <!-- Source: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-bom -->
-        <log4j-bom.version>2.25.3</log4j-bom.version>
+        <log4j-bom.version>2.25.4</log4j-bom.version>
         <!-- Source: https://mvnrepository.com/artifact/de.flapdoodle.embed/de.flapdoodle.embed.mongo -->
         <flapdoodle.version>4.24.0</flapdoodle.version>
         <!-- Source: https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver -->
         <okhttp3.version>5.3.2</okhttp3.version>
-        <!-- Source: https://mvnrepository.com/artifact/com.fasterxml.jackson/jackson-bom -->
-        <jackson-bom.version>2.21.1</jackson-bom.version>
         <!-- Source: https://mvnrepository.com/artifact/tools.jackson.core/jackson-core -->
         <jackson3.version>3.1.2</jackson3.version>
         <!-- Source: https://mvnrepository.com/artifact/commons-io/commons-io -->
@@ -84,7 +82,7 @@
         <!-- Source: https://mvnrepository.com/artifact/org.webjars/swagger-ui -->
         <swagger-ui.version>5.32.4</swagger-ui.version>
         <!-- Source: https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-http -->
-        <jetty.version>12.1.7</jetty.version>
+        <jetty.version>12.1.8</jetty.version>
         <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom -->
         <opentelemetry.version>2.26.1</opentelemetry.version>
         <!-- Source: https://mvnrepository.com/artifact/com.google.guava/guava -->

--- a/src/main/java/uk/gov/companieshouse/DissolutionApplication.java
+++ b/src/main/java/uk/gov/companieshouse/DissolutionApplication.java
@@ -1,13 +1,11 @@
 package uk.gov.companieshouse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlWriteFeature;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -21,17 +19,11 @@ public class DissolutionApplication {
         SpringApplication.run(DissolutionApplication.class, args);
     }
 
-    @Bean
-    @Primary
-    public ObjectMapper configureJsonMapper() {
-        return new ObjectMapper();
-    }
-
     @Bean(name = "xmlMapper")
     public XmlMapper configureXmlMapper() {
-        final XmlMapper xmlMapper = new XmlMapper();
-        xmlMapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
-        return xmlMapper;
+        return XmlMapper.xmlBuilder()
+                .configure(XmlWriteFeature.WRITE_XML_DECLARATION, true)
+                .build();
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/client/DocumentRenderClient.java
+++ b/src/main/java/uk/gov/companieshouse/client/DocumentRenderClient.java
@@ -1,10 +1,10 @@
 package uk.gov.companieshouse.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.config.DocumentRenderConfig;
 import uk.gov.companieshouse.exception.DocumentRenderException;
 import uk.gov.companieshouse.model.dto.documentrender.DissolutionCertificateData;
@@ -28,8 +28,11 @@ public class DocumentRenderClient {
 
     private final DocumentRenderConfig config;
 
-    public DocumentRenderClient(DocumentRenderConfig config) {
+    private final ObjectMapper objectMapper;
+
+    public DocumentRenderClient(DocumentRenderConfig config, ObjectMapper objectMapper) {
         this.config = config;
+        this.objectMapper = objectMapper;
     }
 
     public String generateAndStoreDocument(DissolutionCertificateData data, String templateName, String location) {
@@ -55,8 +58,8 @@ public class DocumentRenderClient {
 
     private String asJsonString(DissolutionCertificateData data) {
         try {
-            return new ObjectMapper().writeValueAsString(data);
-        } catch (JsonProcessingException ex) {
+            return this.objectMapper.writeValueAsString(data);
+        } catch (JacksonException ex) {
             throw new DocumentRenderException("Failed to write dissolution certificate data to JSON string");
         }
     }

--- a/src/main/java/uk/gov/companieshouse/client/DocumentRenderClient.java
+++ b/src/main/java/uk/gov/companieshouse/client/DocumentRenderClient.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.client;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -30,7 +31,7 @@ public class DocumentRenderClient {
 
     private final ObjectMapper objectMapper;
 
-    public DocumentRenderClient(DocumentRenderConfig config, ObjectMapper objectMapper) {
+    public DocumentRenderClient(DocumentRenderConfig config, @Qualifier("jacksonJsonMapper") ObjectMapper objectMapper) {
         this.config = config;
         this.objectMapper = objectMapper;
     }

--- a/src/main/java/uk/gov/companieshouse/client/EmailClient.java
+++ b/src/main/java/uk/gov/companieshouse/client/EmailClient.java
@@ -1,12 +1,12 @@
 package uk.gov.companieshouse.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.chskafka.SendEmail;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -67,7 +67,7 @@ public class EmailClient {
 
             return response;
 
-        } catch(JsonProcessingException ex) {
+        } catch(JacksonException ex) {
             logger.error("Error creating payload", ex);
             throw new EmailSendException(ex.getMessage());
 

--- a/src/main/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapper.java
@@ -1,10 +1,10 @@
 package uk.gov.companieshouse.mapper.chips;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
+import tools.jackson.dataformat.xml.XmlMapper;
 import uk.gov.companieshouse.exception.ChipsMapperException;
 import uk.gov.companieshouse.model.db.dissolution.Company;
 import uk.gov.companieshouse.model.db.dissolution.Dissolution;
@@ -150,7 +150,7 @@ public class ChipsFormDataMapper {
     private String toXml(ChipsFormData form) {
         try {
             return xmlMapper.writeValueAsString(form);
-        } catch (JsonProcessingException ex) {
+        } catch (JacksonException ex) {
             throw new ChipsMapperException(String.format("Failed to map to CHIPS request for company %s", form.getCorporateBody().getIncorporationNumber()), ex);
         }
     }

--- a/src/main/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapper.java
+++ b/src/main/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapper.java
@@ -113,7 +113,7 @@ public class ChipsFormDataMapper {
     }
 
     private List<ChipsOfficer> mapToOfficers(Dissolution dissolution) {
-        return dissolution.getData().getDirectors().stream().map(this::mapToOfficer).collect(Collectors.toList());
+        return dissolution.getData().getDirectors().stream().map(this::mapToOfficer).toList();
     }
 
     private ChipsOfficer mapToOfficer(DissolutionDirector director) {

--- a/src/main/java/uk/gov/companieshouse/model/dto/chips/xml/ChipsCorporateBody.java
+++ b/src/main/java/uk/gov/companieshouse/model/dto/chips/xml/ChipsCorporateBody.java
@@ -1,7 +1,8 @@
 package uk.gov.companieshouse.model.dto.chips.xml;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 import java.util.List;
 

--- a/src/main/java/uk/gov/companieshouse/model/dto/chips/xml/ChipsFormData.java
+++ b/src/main/java/uk/gov/companieshouse/model/dto/chips/xml/ChipsFormData.java
@@ -1,7 +1,8 @@
 package uk.gov.companieshouse.model.dto.chips.xml;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 @JacksonXmlRootElement(localName = "form")
 public class ChipsFormData {

--- a/src/main/java/uk/gov/companieshouse/model/dto/chips/xml/ChipsOfficer.java
+++ b/src/main/java/uk/gov/companieshouse/model/dto/chips/xml/ChipsOfficer.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.model.dto.chips.xml;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 @JacksonXmlRootElement(localName = "officer")
 public class ChipsOfficer {

--- a/src/test/java/uk/gov/companieshouse/client/BarcodeGeneratorClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/client/BarcodeGeneratorClientTest.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -14,6 +12,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.config.BarcodeGeneratorConfig;
 import uk.gov.companieshouse.model.dto.barcode.BarcodeRequest;
 import uk.gov.companieshouse.model.dto.barcode.BarcodeResponse;
@@ -97,7 +97,7 @@ public class BarcodeGeneratorClientTest {
         mockBackEnd.shutdown();
     }
 
-    private String asJsonString(Object obj) throws JsonProcessingException {
+    private String asJsonString(Object obj) throws JacksonException {
         return new ObjectMapper().writeValueAsString(obj);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/client/ChipsClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/client/ChipsClientTest.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -14,6 +12,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.config.ChipsConfig;
 import uk.gov.companieshouse.exception.ChipsNotAvailableException;
 import uk.gov.companieshouse.model.dto.chips.DissolutionChipsRequest;
@@ -83,7 +83,7 @@ public class ChipsClientTest {
     }
 
     @Test
-    void sendDissolutionToChips_sendsDissolutionRequestToChips() throws InterruptedException, JsonProcessingException {
+    void sendDissolutionToChips_sendsDissolutionRequestToChips() throws InterruptedException, JacksonException {
         final DissolutionChipsRequest request = generateDissolutionChipsRequest();
 
         mockBackEnd.enqueue(
@@ -125,7 +125,7 @@ public class ChipsClientTest {
         mockBackEnd.shutdown();
     }
 
-    private String asJsonString(Object obj) throws JsonProcessingException {
+    private String asJsonString(Object obj) throws JacksonException {
         return new ObjectMapper().writeValueAsString(obj);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/client/CompanyOfficersClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/client/CompanyOfficersClientTest.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -14,6 +12,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.config.CompanyOfficersConfig;
 import uk.gov.companieshouse.model.dto.companyofficers.CompanyOfficer;
 import uk.gov.companieshouse.model.dto.companyofficers.CompanyOfficersResponse;
@@ -128,7 +128,7 @@ public class CompanyOfficersClientTest {
         mockBackEnd.shutdown();
     }
 
-    private String asJsonString(Object obj) throws JsonProcessingException {
+    private String asJsonString(Object obj) throws JacksonException {
         return new ObjectMapper().writeValueAsString(obj);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/client/DocumentRenderClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/client/DocumentRenderClientTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.client;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -13,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.config.DocumentRenderConfig;
 import uk.gov.companieshouse.model.dto.documentrender.DissolutionCertificateData;
 
@@ -41,13 +41,14 @@ public class DocumentRenderClientTest {
     private DocumentRenderConfig documentRenderConfig;
 
     @BeforeAll
-    public static void setUp() throws IOException {
+    static void setUp() throws IOException {
         mockBackEnd = new MockWebServer();
         mockBackEnd.start();
     }
 
     @BeforeEach
     void initialize() {
+        client = new DocumentRenderClient(documentRenderConfig, new ObjectMapper());
         String baseUrl = String.format("http://localhost:%s", mockBackEnd.getPort());
 
         when(documentRenderConfig.getDocumentRenderHost()).thenReturn(baseUrl);
@@ -96,7 +97,7 @@ public class DocumentRenderClientTest {
     }
 
     @AfterAll
-    public static void tearDown() throws IOException {
+    static void tearDown() throws IOException {
         mockBackEnd.shutdown();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/client/DocumentRenderClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/client/DocumentRenderClientTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.fixtures.DissolutionFixtures.generateDissolutionCertificateData;
 
 @ExtendWith(MockitoExtension.class)
-public class DocumentRenderClientTest {
+class DocumentRenderClientTest {
 
     private static final String API_KEY = "some-api-key";
 
@@ -32,7 +32,7 @@ public class DocumentRenderClientTest {
     private static final String TEMPLATE_NAME = "ds01.html";
     private static final DissolutionCertificateData CERTIFICATE_DATA = generateDissolutionCertificateData();
 
-    public static MockWebServer mockBackEnd;
+    static MockWebServer mockBackEnd;
 
     @InjectMocks
     private DocumentRenderClient client;

--- a/src/test/java/uk/gov/companieshouse/client/DocumentRenderClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/client/DocumentRenderClientTest.java
@@ -96,6 +96,39 @@ class DocumentRenderClientTest {
         assertEquals(LOCATION, recordedRequest.getHeader("Location"));
     }
 
+    @Test
+    void generateAndStoreDocument_throwsDocumentRenderException_whenJsonMappingFails() {
+        DocumentRenderClient failingClient = new DocumentRenderClient(documentRenderConfig, new ObjectMapper() {
+            @Override
+            public String writeValueAsString(Object value) {
+                throw new tools.jackson.core.JacksonException("fail") {};
+            }
+        });
+        when(documentRenderConfig.getDocumentRenderHost()).thenReturn("http://localhost:1234");
+        when(documentRenderConfig.getApiKey()).thenReturn(API_KEY);
+        uk.gov.companieshouse.exception.DocumentRenderException ex = org.junit.jupiter.api.Assertions.assertThrows(
+            uk.gov.companieshouse.exception.DocumentRenderException.class,
+            () -> failingClient.generateAndStoreDocument(CERTIFICATE_DATA, TEMPLATE_NAME, LOCATION)
+        );
+        assertEquals("Failed to write dissolution certificate data to JSON string", ex.getMessage());
+    }
+
+    @Test
+    void generateAndStoreDocument_throwsRuntimeException_whenNoLocationHeaderReturned() {
+        mockBackEnd.enqueue(
+            new MockResponse()
+                .setResponseCode(HttpStatus.CREATED.value())
+                // No Location header
+        );
+        when(documentRenderConfig.getDocumentRenderHost()).thenReturn(String.format("http://localhost:%s", mockBackEnd.getPort()));
+        when(documentRenderConfig.getApiKey()).thenReturn(API_KEY);
+        RuntimeException ex = org.junit.jupiter.api.Assertions.assertThrows(
+            RuntimeException.class,
+            () -> client.generateAndStoreDocument(CERTIFICATE_DATA, TEMPLATE_NAME, LOCATION)
+        );
+        assertEquals("No location header returned from Document Render Service", ex.getMessage());
+    }
+
     @AfterAll
     static void tearDown() throws IOException {
         mockBackEnd.shutdown();

--- a/src/test/java/uk/gov/companieshouse/client/EmailClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/client/EmailClientTest.java
@@ -1,10 +1,7 @@
 package uk.gov.companieshouse.client;
 
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +12,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.chskafka.SendEmail;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -55,11 +54,8 @@ class EmailClientTest {
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(emailClient, "objectMapper", new ObjectMapper());
+        emailClient = new EmailClient("http://kafka:9092", internalApiClientSupplier, logger, new ObjectMapper());
     }
-
-    @AfterEach
-    void tearDown() {}
 
     @Test
     void givenValidPayload_whenSignatoryToSignEmailData_thenReturnSuccess() throws ApiErrorResponseException {
@@ -325,10 +321,10 @@ class EmailClientTest {
     }
 
     @Test
-    void givenInvalidPayload_whenConfirmationEmailClientThrowsJsonException_thenReturnError() throws JsonProcessingException {
+    void givenInvalidPayload_whenConfirmationEmailClientThrowsJsonException_thenReturnError() throws JacksonException {
         // Arrange:
         ObjectMapper mockObjectMapper = mock(ObjectMapper.class);
-        when(mockObjectMapper.writeValueAsString(any())).thenThrow(JsonProcessingException.class);
+        when(mockObjectMapper.writeValueAsString(any())).thenThrow(JacksonException.class);
 
         ReflectionTestUtils.setField(emailClient, "objectMapper", mockObjectMapper);
 

--- a/src/test/java/uk/gov/companieshouse/client/PaymentsClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/client/PaymentsClientTest.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -13,6 +11,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.config.PaymentsConfig;
 import uk.gov.companieshouse.model.dto.payment.RefundRequest;
 import uk.gov.companieshouse.model.dto.payment.RefundResponse;
@@ -96,7 +96,7 @@ public class PaymentsClientTest {
         assertEquals("application/json", recordedRequest.getHeader("Content-Type"));
     }
 
-    private String asJsonString(Object obj) throws JsonProcessingException {
+    private String asJsonString(Object obj) throws JacksonException {
         return new ObjectMapper().writeValueAsString(obj);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/controller/DissolutionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/DissolutionControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -9,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.util.security.EricConstants;
 import uk.gov.companieshouse.api.util.security.Permission;

--- a/src/test/java/uk/gov/companieshouse/controller/DissolutionDirectorControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/DissolutionDirectorControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -9,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.api.util.security.EricConstants;
 import uk.gov.companieshouse.api.util.security.Permission;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionDirectorPatchRequest;

--- a/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -8,6 +7,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.api.util.security.EricConstants;
 import uk.gov.companieshouse.api.util.security.SecurityConstants;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionGetResponse;

--- a/src/test/java/uk/gov/companieshouse/controller/ResponseControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/ResponseControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -8,6 +7,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.companieshouse.api.util.security.EricConstants;
 import uk.gov.companieshouse.api.util.security.SecurityConstants;
 import uk.gov.companieshouse.fixtures.ChipsFixtures;

--- a/src/test/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapperTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.mapper.chips;
 
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,6 +8,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.dataformat.xml.XmlMapper;
 import uk.gov.companieshouse.model.db.dissolution.DirectorApproval;
 import uk.gov.companieshouse.model.db.dissolution.Dissolution;
 import uk.gov.companieshouse.model.db.dissolution.DissolutionDirector;

--- a/src/test/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapperTest.java
@@ -31,7 +31,7 @@ import static uk.gov.companieshouse.fixtures.DissolutionFixtures.*;
 import static uk.gov.companieshouse.fixtures.PaymentFixtures.generatePaymentInformation;
 
 @ExtendWith(MockitoExtension.class)
-public class ChipsFormDataMapperTest {
+class ChipsFormDataMapperTest {
 
     private static final String APPLICANT_EMAIL = "applicant@mail.com";
     private static final String COMPANY_NAME = "Some Company Name";
@@ -51,7 +51,7 @@ public class ChipsFormDataMapperTest {
     private ArgumentCaptor<ChipsFormData> requestCaptor;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() {
         dissolution = generateDissolution();
         dissolution.setPaymentInformation(generatePaymentInformation());
         dissolution.getData().setDirectors(Collections.emptyList());
@@ -62,7 +62,7 @@ public class ChipsFormDataMapperTest {
     }
 
     @Test
-    public void mapToChipsFormDataXml_writesToAnXmlString_andReturnsIt() throws Exception {
+    void mapToChipsFormDataXml_writesToAnXmlString_andReturnsIt() {
         final String result = mapper.mapToChipsFormDataXml(dissolution);
 
         verify(xmlMapper).writeValueAsString(any());
@@ -71,7 +71,7 @@ public class ChipsFormDataMapperTest {
     }
 
     @Test
-    public void mapToChipsFormDataXml_setsTheFormTypeForDs01() throws Exception {
+    void mapToChipsFormDataXml_setsTheFormTypeForDs01() {
         dissolution.getData().getApplication().setType(ApplicationType.DS01);
 
         mapper.mapToChipsFormDataXml(dissolution);
@@ -84,7 +84,7 @@ public class ChipsFormDataMapperTest {
     }
 
     @Test
-    public void mapToChipsFormDataXml_setsTheFormTypeForLlds01() throws Exception {
+    void mapToChipsFormDataXml_setsTheFormTypeForLlds01() {
         dissolution.getData().getApplication().setType(ApplicationType.LLDS01);
 
         mapper.mapToChipsFormDataXml(dissolution);
@@ -97,7 +97,7 @@ public class ChipsFormDataMapperTest {
     }
 
     @Test
-    public void mapToChipsFormDataXml_setsTheFormVersion() throws Exception {
+    void mapToChipsFormDataXml_setsTheFormVersion() {
         mapper.mapToChipsFormDataXml(dissolution);
 
         verify(xmlMapper).writeValueAsString(requestCaptor.capture());
@@ -108,7 +108,7 @@ public class ChipsFormDataMapperTest {
     }
 
     @Test
-    public void mapToChipsFormDataXml_setsTheFilingDetailsCorrectly() throws Exception {
+    void mapToChipsFormDataXml_setsTheFilingDetailsCorrectly() {
         dissolution.getData().getApplication().setReference(DISSOLUTION_REFERENCE);
         dissolution.getData().getApplication().setBarcode(DISSOLUTION_BARCODE);
         dissolution.getCreatedBy().setDateTime(LocalDateTime.of(2020, 1, 1, 0, 0));
@@ -131,7 +131,7 @@ public class ChipsFormDataMapperTest {
     }
 
     @Test
-    public void mapToChipsFormDataXml_setsTheFilingDetails_presenterDetailsCorrectly() throws Exception {
+    void mapToChipsFormDataXml_setsTheFilingDetails_presenterDetailsCorrectly() {
         dissolution.getCreatedBy().setEmail(APPLICANT_EMAIL);
 
         mapper.mapToChipsFormDataXml(dissolution);
@@ -145,7 +145,7 @@ public class ChipsFormDataMapperTest {
     }
 
     @Test
-    public void mapToChipsFormDataXml_setsTheFilingDetails_paymentDetailsCorrectly_payByAccountFeatureToggleOn() throws Exception {
+    void mapToChipsFormDataXml_setsTheFilingDetails_paymentDetailsCorrectly_payByAccountFeatureToggleOn() {
         dissolution.getPaymentInformation().setMethod(PaymentMethod.ACCOUNT);
         dissolution.getPaymentInformation().setAccountNumber(ACCOUNT_NUMBER);
 
@@ -161,7 +161,7 @@ public class ChipsFormDataMapperTest {
     }
 
     @Test
-    public void mapToChipsFormDataXml_setsTheFilingDetails_paymentDetailsCorrectly_payByAccountFeatureToggleOff() throws Exception {
+    void mapToChipsFormDataXml_setsTheFilingDetails_paymentDetailsCorrectly_payByAccountFeatureToggleOff() {
         dissolution.getPaymentInformation().setMethod(PaymentMethod.CREDIT_CARD);
         dissolution.getPaymentInformation().setReference(PAYMENT_REFERENCE);
 
@@ -177,7 +177,7 @@ public class ChipsFormDataMapperTest {
     }
 
     @Test
-    public void mapToChipsFormDataXml_setsTheCorporateBody_companyInfoCorrectly() throws Exception {
+    void mapToChipsFormDataXml_setsTheCorporateBody_companyInfoCorrectly() {
         dissolution.getCompany().setName(COMPANY_NAME);
         dissolution.getCompany().setNumber(COMPANY_NUMBER);
 
@@ -192,7 +192,7 @@ public class ChipsFormDataMapperTest {
     }
 
     @Test
-    public void mapToChipsFormDataXml_setsTheCorporateBody_officersCorrectly() throws Exception {
+    void mapToChipsFormDataXml_setsTheCorporateBody_officersCorrectly() {
         DirectorApproval approvalOne = generateDirectorApproval();
         approvalOne.setDateTime(LocalDateTime.of(2020, 1, 1, 12, 30));
         approvalOne.setIpAddress("192.168.0.2");
@@ -223,9 +223,9 @@ public class ChipsFormDataMapperTest {
 
         assertEquals(2, request.getCorporateBody().getOfficers().size());
 
-        assertEquals("John James", request.getCorporateBody().getOfficers().get(0).getPersonName().getForename());
-        assertEquals("DOE", request.getCorporateBody().getOfficers().get(0).getPersonName().getSurname());
-        assertEquals("2020-01-01", request.getCorporateBody().getOfficers().get(0).getSignDate());
+        assertEquals("John James", request.getCorporateBody().getOfficers().getFirst().getPersonName().getForename());
+        assertEquals("DOE", request.getCorporateBody().getOfficers().getFirst().getPersonName().getSurname());
+        assertEquals("2020-01-01", request.getCorporateBody().getOfficers().getFirst().getSignDate());
         assertEquals("mail1", request.getCorporateBody().getOfficers().get(0).getEmail());
         assertEquals("192.168.0.2", request.getCorporateBody().getOfficers().get(0).getIpAddress());
 

--- a/src/test/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/mapper/chips/ChipsFormDataMapperTest.java
@@ -8,7 +8,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.core.JacksonException;
 import tools.jackson.dataformat.xml.XmlMapper;
+import uk.gov.companieshouse.exception.ChipsMapperException;
 import uk.gov.companieshouse.model.db.dissolution.DirectorApproval;
 import uk.gov.companieshouse.model.db.dissolution.Dissolution;
 import uk.gov.companieshouse.model.db.dissolution.DissolutionDirector;
@@ -236,4 +238,16 @@ class ChipsFormDataMapperTest {
         assertEquals("Mr. Accountant", request.getCorporateBody().getOfficers().get(1).getOnBehalfName());
         assertEquals("192.168.0.3", request.getCorporateBody().getOfficers().get(1).getIpAddress());
     }
+
+    @Test
+    void mapToChipsFormDataXml_throwsChipsMapperException_whenXmlMappingFails() throws Exception {
+        when(xmlMapper.writeValueAsString(any())).thenThrow(new JacksonException("XML error") {});
+        dissolution.getCompany().setNumber(COMPANY_NUMBER);
+        ChipsMapperException ex = org.junit.jupiter.api.Assertions.assertThrows(
+            ChipsMapperException.class,
+            () -> mapper.mapToChipsFormDataXml(dissolution)
+        );
+        assertEquals("Failed to map to CHIPS request for company " + COMPANY_NUMBER, ex.getMessage());
+    }
+
 }


### PR DESCRIPTION
## Description

Spring Boot now uses Jackson 3 as its preferred JSON library. Jackson 3 uses new group IDs and package names with com.fasterxml.jackson becoming tools.jackson. An exception to this is the jackson-annotations module which continues to use the com.fasterxml.jackson.core group ID and com.fasterxml.jackson.annotation package. To learn more about the changes in Jackson 3, refer to the [Jackson wiki](https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0#major-changesfeatures-in-30).

Packages and dependencies have been updated to use the latest Jackson 3 libraries.

## Jira Ticket

[ASM-1862](https://companieshouse.atlassian.net/browse/ASM-1862)

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [ ] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description


[ASM-1862]: https://companieshouse.atlassian.net/browse/ASM-1862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ