### PR TITLE
ASM-2377 Update dependency versions in pom.xml for compatibility and security improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <!-- Source: https://mvnrepository.com/artifact/com.google.cloud.tools/jib-maven-plugin -->
         <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
         <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
-        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <!-- Source: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-resources-plugin -->
@@ -36,15 +36,15 @@
 
         <!-- Companies House Internal Dependencies -->
         <api-helper-java.version>3.0.4</api-helper-java.version>
-        <api-security-java.version>2.0.26</api-security-java.version>
-        <api-sdk-java.version>6.6.20</api-sdk-java.version>
-        <private-api-sdk-java.version>6.0.9</private-api-sdk-java.version>
-        <api-sdk-manager-java-library.version>3.0.22</api-sdk-manager-java-library.version>
-        <structured-logging.version>3.0.56</structured-logging.version>
+        <api-security-java.version>2.0.27</api-security-java.version>
+        <api-sdk-java.version>6.6.23</api-sdk-java.version>
+        <private-api-sdk-java.version>6.0.23</private-api-sdk-java.version>
+        <api-sdk-manager-java-library.version>3.0.23</api-sdk-manager-java-library.version>
+        <structured-logging.version>3.0.57</structured-logging.version>
         <environment-reader-library.version>3.0.5</environment-reader-library.version>
-        <java-session-handler.version>4.1.17</java-session-handler.version>
-        <ch-kafka.version>3.0.12</ch-kafka.version>
-        <kafka-models.version>3.0.31</kafka-models.version>
+        <java-session-handler.version>4.1.20</java-session-handler.version>
+        <ch-kafka.version>3.0.15</ch-kafka.version>
+        <kafka-models.version>3.0.33</kafka-models.version>
 
         <!-- Dependency Versions -->
         <!-- Source: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies -->
@@ -56,15 +56,16 @@
         <!-- Source: https://mvnrepository.com/artifact/org.apache.avro/avro -->
         <avro.version>1.12.1</avro.version>
         <!-- Source: https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients -->
-        <kafka-clients.version>4.2.0</kafka-clients.version>
+        <!-- This (latest) version is vulnerable, but no fix available as yet https://www.cve.org/CVERecord?id=CVE-2026-41115       -->
+        <kafka-clients.version>4.3.0</kafka-clients.version>
         <!-- Source: https://mvnrepository.com/artifact/software.amazon.awssdk/bom -->
-        <aws-java-sdk.version>2.44.4</aws-java-sdk.version>
+        <aws-java-sdk.version>2.46.0</aws-java-sdk.version>
         <!-- Source: https://mvnrepository.com/artifact/io.netty/netty-all -->
-        <netty.version>4.2.13.Final</netty.version>
+        <netty.version>4.2.14.Final</netty.version>
         <!-- Source: https://mvnrepository.com/artifact/io.projectreactor.netty/reactor-netty-core -->
         <reactor-netty-core.version>1.3.5</reactor-netty-core.version>
         <!-- Source: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-bom -->
-        <log4j-bom.version>2.25.4</log4j-bom.version>
+        <log4j-bom.version>2.26.0</log4j-bom.version>
         <!-- Source: https://mvnrepository.com/artifact/de.flapdoodle.embed/de.flapdoodle.embed.mongo -->
         <flapdoodle.version>4.24.0</flapdoodle.version>
         <!-- Source: https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver -->
@@ -72,13 +73,13 @@
         <!-- Source: https://mvnrepository.com/artifact/commons-io/commons-io -->
         <commons-io.version>2.22.0</commons-io.version>
         <!-- Source: https://mvnrepository.com/artifact/org.json/json -->
-        <org-json.version>20251224</org-json.version>
+        <org-json.version>20260522</org-json.version>
         <!-- Source: https://mvnrepository.com/artifact/org.webjars/swagger-ui -->
-        <swagger-ui.version>5.32.5</swagger-ui.version>
+        <swagger-ui.version>5.32.6</swagger-ui.version>
         <!-- Source: https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-http -->
         <jetty.version>12.1.9</jetty.version>
         <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom -->
-        <opentelemetry.version>2.27.0</opentelemetry.version>
+        <opentelemetry.version>2.28.1</opentelemetry.version>
         <!-- Source: https://mvnrepository.com/artifact/com.google.guava/guava -->
         <guava.version>33.6.0-jre</guava.version>
         <!-- Source: https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom -->
@@ -212,7 +213,7 @@
             </dependency>
 
             <!-- Source: https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core -->
-            <!-- Addresses https://www.cve.org/CVERecord?id=CVE-2026-41284 - ToDo - Can probably be removed after 03/06/2026 following Spring Boot 4.0.7 release          -->
+            <!-- Addresses https://www.cve.org/CVERecord?id=CVE-2026-41284          -->
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>


### PR DESCRIPTION
## Description

Routine dependency patch updates across Companies House internal libraries, third-party dependencies, and Maven build plugins. Includes an upgrade to the latest Kafka Clients version, which carries a known CVE with no upstream fix currently available.

---

## Dependency Changes

### Companies House Internal Libraries
| Dependency | From | To |
|---|---|---|
| api-security-java | 2.0.26 | **2.0.27** |
| api-sdk-java | 6.6.20 | **6.6.23** |
| private-api-sdk-java | 6.0.9 | **6.0.23** |
| api-sdk-manager-java-library | 3.0.22 | **3.0.23** |
| structured-logging | 3.0.56 | **3.0.57** |
| java-session-handler | 4.1.17 | **4.1.20** |
| ch-kafka | 3.0.12 | **3.0.15** |
| kafka-models | 3.0.31 | **3.0.33** |

### Third-Party Libraries
| Dependency | From | To |
|---|---|---|
| kafka-clients | 4.2.0 | **4.3.0** ⚠️ |
| aws-java-sdk (BOM) | 2.44.4 | **2.46.0** |
| Netty | 4.2.13.Final | **4.2.14.Final** |
| Log4j BOM | 2.25.4 | **2.26.0** |
| OpenTelemetry Instrumentation BOM | 2.27.0 | **2.28.1** |
| org.json | 20251224 | **20260522** |
| Swagger UI | 5.32.5 | **5.32.6** |

### Maven Plugins
| Plugin | From | To |
|---|---|---|
| maven-surefire-plugin | 3.5.5 | **3.5.6** |

---

## Security Notes

### ⚠️ Outstanding Vulnerability
| CVE | Package | Version | Status |
|---|---|---|---|
| [CVE-2026-41115](https://www.cve.org/CVERecord?id=CVE-2026-41115) | kafka-clients | 4.3.0 | No fix available — 4.3.0 is the latest release. Monitor for upstream patch. |

### Previously Fixed CVEs (retained from master)
| CVE | Package | Fix Version |
|---|---|---|
| CVE-2026-41284 | tomcat-embed-core / tomcat-embed-websocket | 11.0.22 |
| CVE-2026-1605 | jetty-ee10-webapp | 12.0.35 |

---

## Follow-up Actions
- [ ] Monitor [CVE-2026-41115](https://www.cve.org/CVERecord?id=CVE-2026-41115) (Kafka Clients) and upgrade `kafka-clients` as soon as a patched version is released.
- [ ] Review whether the explicit Tomcat override for CVE-2026-41284 can be removed once Spring Boot 4.0.7 is available and adopted.

## Jira Ticket

[ASM-2377](https://companieshouse.atlassian.net/browse/ASM-2377)

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [ ] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description


[ASM-2377]: https://companieshouse.atlassian.net/browse/ASM-2377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ