### PR TITLE
ASM-2421 Update dependency versions in pom.xml for compatibility and security improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,17 +59,17 @@
         <!-- This (latest) version is vulnerable, but no fix available as yet https://www.cve.org/CVERecord?id=CVE-2026-41115       -->
         <kafka-clients.version>4.3.0</kafka-clients.version>
         <!-- Source: https://mvnrepository.com/artifact/software.amazon.awssdk/bom -->
-        <aws-java-sdk.version>2.46.0</aws-java-sdk.version>
+        <aws-java-sdk.version>2.46.6</aws-java-sdk.version>
         <!-- Source: https://mvnrepository.com/artifact/io.netty/netty-all -->
-        <netty.version>4.2.14.Final</netty.version>
+        <netty.version>4.2.15.Final</netty.version>
         <!-- Source: https://mvnrepository.com/artifact/io.projectreactor.netty/reactor-netty-core -->
-        <reactor-netty-core.version>1.3.5</reactor-netty-core.version>
+        <reactor-netty-core.version>1.3.6</reactor-netty-core.version>
         <!-- Source: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-bom -->
         <log4j-bom.version>2.26.0</log4j-bom.version>
         <!-- Source: https://mvnrepository.com/artifact/de.flapdoodle.embed/de.flapdoodle.embed.mongo -->
-        <flapdoodle.version>4.24.0</flapdoodle.version>
+        <flapdoodle.version>4.33.0</flapdoodle.version>
         <!-- Source: https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver -->
-        <okhttp3.version>5.3.2</okhttp3.version>
+        <okhttp3.version>5.4.0</okhttp3.version>
         <!-- Source: https://mvnrepository.com/artifact/commons-io/commons-io -->
         <commons-io.version>2.22.0</commons-io.version>
         <!-- Source: https://mvnrepository.com/artifact/org.json/json -->
@@ -77,7 +77,7 @@
         <!-- Source: https://mvnrepository.com/artifact/org.webjars/swagger-ui -->
         <swagger-ui.version>5.32.6</swagger-ui.version>
         <!-- Source: https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-http -->
-        <jetty.version>12.1.9</jetty.version>
+        <jetty.version>12.1.10</jetty.version>
         <!-- Source: https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-bom -->
         <opentelemetry.version>2.28.1</opentelemetry.version>
         <!-- Source: https://mvnrepository.com/artifact/com.google.guava/guava -->
@@ -132,7 +132,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>12.1.9</version>
+                <version>12.1.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -157,7 +157,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>4.34.1</version>
+                <version>4.35.0</version>
                 <scope>compile</scope>
             </dependency>
 
@@ -192,7 +192,7 @@
             <dependency> <!-- Fix for CVE CVE-2026-1605 https://github.com/jetty/jetty.project/security/advisories/GHSA-xxh7-fcf3-rj7f -->
                 <groupId>org.eclipse.jetty.ee10</groupId>
                 <artifactId>jetty-ee10-webapp</artifactId>
-                <version>12.0.35</version>
+                <version>12.0.36</version>
             </dependency>
 
             <!-- Source: https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom -->
@@ -200,14 +200,6 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-bom</artifactId>
                 <version>${kotlin.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -228,6 +220,13 @@
             </dependency>
             <!-- END CVE           -->
 
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
 
     </dependencyManagement>
@@ -320,7 +319,7 @@
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-logback-appender-1.0</artifactId>
-            <version>2.27.0-alpha</version>
+            <version>${opentelemetry.version}-alpha</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
## Description

Updated `pom.xml` dependency versions to current patch releases for security and compatibility improvements (AWS SDK, Netty, Reactor Netty, Flapdoodle, OkHttp MockWebServer, Jetty, and Protobuf). Also aligned OpenTelemetry logback appender versioning with the shared `opentelemetry.version` property and tidied dependency-management ordering. No application logic changes were made.

## Jira Ticket
[ASM-2421](https://companieshouse.atlassian.net/browse/ASM-2421)

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [x] Branch named {feature|hotfix|task}/{S4-*}
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] All unit tests passing
- [ ] API (Karate) tests passing
- [ ] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description


[ASM-2421]: https://companieshouse.atlassian.net/browse/ASM-2421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ