### PR TITLE
remove aws env pointers for iam role to take precedence

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,7 @@ api:
   url: ${API_URL}
 
 aws:
-  accessKeyId: ${AWS_ACCESS_KEY_ID}
   region: ${ENV_REGION_AWS}
-  secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
 
 barcodeGenerator:
   host: ${BARCODE_SERVICE_URL}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,9 +4,7 @@ api:
   url: http://api
 
 aws:
-  accessKeyId: some-access-key
   region: eu-west-2
-  secretAccessKey: some-secret-key
 
 barcodeGenerator:
   host: http://barcode-generator


### PR DESCRIPTION
## Description

Remove access key pointers so ecs role can take precedence. Currently its still trying to use an expired key.
Vault keys to be removed.

## Jira Ticket

Please add link to Jira ticket

## Coding Standards

Code Style Guide: https://github.com/companieshouse/dissolution-web/wiki/Code-Style-Guide

## Checklist

- [ ] 3 Amigos
- [ ] Acceptance Criteria met
- [ ] Branch named {feature|hotfix|task}/{S4-*}
- [ ] Commit messages are meaningful
- [ ] Manually tested
- [ ] All unit tests passing
- [ ] API (Karate) tests passing
- [ ] Pulled latest master into feature branch
- [ ] Code reviewed
- [ ] New Docker environment variables have also been added to the revel1 environment and cidev environment
- [ ] If your pull request depends on any other, please link them in the description
