### PR TITLE
feat (FS-394): Add Transaction Service and Interceptor to pre-fetch transaction data

### DIFF
--- a/src/main/java/uk/gov/companieshouse/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.TokenPermissionsInterceptor;
 import uk.gov.companieshouse.interceptor.DissolutionTokenPermissionsInterceptor;
+import uk.gov.companieshouse.interceptor.TransactionInterceptor;
 
 @Configuration
 public class SecurityConfig implements WebMvcConfigurer {
@@ -26,6 +27,11 @@ public class SecurityConfig implements WebMvcConfigurer {
         "/dissolution-api/healthcheck"
     );
 
+    private static final String[] TRANSACTIONS_INCLUDE_LIST = {
+            "/transactions/**",
+            "/private/transactions/**",
+    };
+
     @Autowired
     private TokenPermissionsInterceptor tokenPermissionsInterceptor;
 
@@ -35,10 +41,14 @@ public class SecurityConfig implements WebMvcConfigurer {
     @Autowired
     private InternalUserInterceptor apiKeyPermissionsInterceptor;
 
+    @Autowired
+    private TransactionInterceptor transactionInterceptor;
+
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(tokenPermissionsInterceptor).addPathPatterns(URI_PATTERN).excludePathPatterns(TOKEN_PERMISSION_AUTH_EXCLUDE_LIST);
         registry.addInterceptor(dissolutionTokenPermissionsInterceptor).addPathPatterns(URI_PATTERN).excludePathPatterns(TOKEN_PERMISSION_AUTH_EXCLUDE_LIST);
         registry.addInterceptor(apiKeyPermissionsInterceptor).addPathPatterns(API_KEY_PERMISSION_AUTH_INCLUDE_LIST);
+        registry.addInterceptor(transactionInterceptor).addPathPatterns(TRANSACTIONS_INCLUDE_LIST);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.config;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -32,17 +31,21 @@ public class SecurityConfig implements WebMvcConfigurer {
             "/private/transactions/**",
     };
 
-    @Autowired
-    private TokenPermissionsInterceptor tokenPermissionsInterceptor;
+    private final TokenPermissionsInterceptor tokenPermissionsInterceptor;
+    private final DissolutionTokenPermissionsInterceptor dissolutionTokenPermissionsInterceptor;
+    private final InternalUserInterceptor apiKeyPermissionsInterceptor;
+    private final TransactionInterceptor transactionInterceptor;
 
-    @Autowired
-    private DissolutionTokenPermissionsInterceptor dissolutionTokenPermissionsInterceptor;
-
-    @Autowired
-    private InternalUserInterceptor apiKeyPermissionsInterceptor;
-
-    @Autowired
-    private TransactionInterceptor transactionInterceptor;
+    public SecurityConfig(
+            TokenPermissionsInterceptor tokenPermissionsInterceptor,
+            DissolutionTokenPermissionsInterceptor dissolutionTokenPermissionsInterceptor,
+            InternalUserInterceptor apiKeyPermissionsInterceptor,
+            TransactionInterceptor transactionInterceptor) {
+        this.tokenPermissionsInterceptor = tokenPermissionsInterceptor;
+        this.dissolutionTokenPermissionsInterceptor = dissolutionTokenPermissionsInterceptor;
+        this.apiKeyPermissionsInterceptor = apiKeyPermissionsInterceptor;
+        this.transactionInterceptor = transactionInterceptor;
+    }
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {

--- a/src/main/java/uk/gov/companieshouse/interceptor/TransactionInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/interceptor/TransactionInterceptor.java
@@ -1,0 +1,60 @@
+package uk.gov.companieshouse.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
+import uk.gov.companieshouse.service.TransactionService;
+
+import java.util.Map;
+
+import static uk.gov.companieshouse.model.Constants.TRANSACTION_ID_KEY;
+import static uk.gov.companieshouse.model.Constants.TRANSACTION_KEY;
+
+@Component
+public class TransactionInterceptor implements HandlerInterceptor {
+
+    private final TransactionService transactionService;
+    private final Logger logger;
+
+    public TransactionInterceptor(TransactionService transactionService, Logger logger) {
+        this.transactionService = transactionService;
+        this.logger = logger;
+    }
+
+    @Override
+    public boolean preHandle(@NonNull HttpServletRequest request,
+                             @NonNull HttpServletResponse response,
+                             @NonNull Object handler) {
+        final var passThroughHeader = request.getHeader(ApiSdkManager.getEricPassthroughTokenHeader());
+        final var transactionId = getTransactionId(request);
+
+        if (StringUtils.isBlank(transactionId)) {
+            logger.info("Transaction ID missing from request");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return false;
+        }
+
+        try {
+            final var transaction = transactionService.getTransaction(transactionId, passThroughHeader);
+            logger.info("Retrieved transaction details for: " + transactionId);
+            request.setAttribute(TRANSACTION_KEY, transaction);
+            return true;
+        } catch (Exception e) {
+            logger.error("Failed to retrieve transaction details for: " + transactionId, e);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return false;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private String getTransactionId(HttpServletRequest request) {
+        final Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        return pathVariables.get(TRANSACTION_ID_KEY);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/model/Constants.java
+++ b/src/main/java/uk/gov/companieshouse/model/Constants.java
@@ -36,4 +36,12 @@ public final class Constants {
    public static final String CONTENT_TYPE_HTML = "text/html";
    public static final String CONTENT_TYPE_JSON = "application/json";
    public static final String CONTENT_TYPE_PDF = "application/pdf";
+
+   public static final String ERIC_REQUEST_ID_KEY = "X-Request-Id";
+
+   /* Path attributes */
+   public static final String TRANSACTION_ID_KEY = "transaction_id";
+
+    /* Request attributes */
+   public static final String TRANSACTION_KEY = "transaction";
 }

--- a/src/main/java/uk/gov/companieshouse/service/TransactionService.java
+++ b/src/main/java/uk/gov/companieshouse/service/TransactionService.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.api.sdk.ApiClientService;
+import uk.gov.companieshouse.exception.ServiceException;
+
+import java.io.IOException;
+
+@Service
+public class TransactionService {
+
+    private final ApiClientService apiClientService;
+
+    public TransactionService(ApiClientService apiClientService) {
+        this.apiClientService = apiClientService;
+    }
+
+    public Transaction getTransaction(String transactionId, String passthroughHeader) throws ServiceException {
+        try {
+            final var uri = "/transactions/" + transactionId;
+            return apiClientService.getApiClient(passthroughHeader)
+                    .transactions()
+                    .get(uri)
+                    .execute()
+                    .getData();
+        } catch (URIValidationException | IOException e) {
+            throw new ServiceException("Failed to retrieve transaction details for: " + transactionId, e);
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/controller/DissolutionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/DissolutionControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.controller;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
@@ -22,6 +23,7 @@ import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchRequest;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionPatchResponse;
 import uk.gov.companieshouse.service.CompanyOfficerService;
 import uk.gov.companieshouse.client.CompanyProfileClientImpl;
+import uk.gov.companieshouse.service.TransactionService;
 import uk.gov.companieshouse.service.dissolution.DissolutionService;
 import uk.gov.companieshouse.service.dissolution.validator.DissolutionValidator;
 import uk.gov.companieshouse.service.payment.PaymentService;
@@ -70,6 +72,9 @@ class DissolutionControllerTest {
 
     @MockitoBean
     private CompanyOfficerService companyOfficerService;
+
+    @MockitoBean
+    private TransactionService transactionService;
 
     @MockitoBean
     private PaymentService paymentService;

--- a/src/test/java/uk/gov/companieshouse/controller/DissolutionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/DissolutionControllerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.controller;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;

--- a/src/test/java/uk/gov/companieshouse/controller/DissolutionDirectorControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/DissolutionDirectorControllerTest.java
@@ -13,6 +13,7 @@ import uk.gov.companieshouse.api.util.security.EricConstants;
 import uk.gov.companieshouse.api.util.security.Permission;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionDirectorPatchRequest;
 import uk.gov.companieshouse.model.dto.dissolution.DissolutionDirectorPatchResponse;
+import uk.gov.companieshouse.service.TransactionService;
 import uk.gov.companieshouse.service.dissolution.director.DissolutionDirectorService;
 
 import java.util.Optional;
@@ -42,6 +43,9 @@ class DissolutionDirectorControllerTest {
 
     @MockitoBean
     private DissolutionDirectorService service;
+
+    @MockitoBean
+    private TransactionService transactionService;
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/PaymentControllerTest.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.model.dto.payment.PaymentGetResponse;
 import uk.gov.companieshouse.model.dto.payment.PaymentPatchRequest;
 import uk.gov.companieshouse.model.enums.ApplicationStatus;
 import uk.gov.companieshouse.model.enums.PaymentStatus;
+import uk.gov.companieshouse.service.TransactionService;
 import uk.gov.companieshouse.service.dissolution.DissolutionService;
 import uk.gov.companieshouse.service.dissolution.validator.PaymentValidator;
 import uk.gov.companieshouse.service.payment.PaymentService;
@@ -47,6 +48,9 @@ class PaymentControllerTest {
 
     @MockitoBean
     private PaymentService paymentService;
+
+    @MockitoBean
+    private TransactionService transactionService;
 
     @MockitoBean
     private PaymentValidator paymentValidator;

--- a/src/test/java/uk/gov/companieshouse/controller/ResendEmailControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/ResendEmailControllerTest.java
@@ -11,6 +11,7 @@ import uk.gov.companieshouse.api.util.security.Permission;
 import uk.gov.companieshouse.api.util.security.SecurityConstants;
 import uk.gov.companieshouse.model.db.dissolution.Dissolution;
 import uk.gov.companieshouse.repository.DissolutionRepository;
+import uk.gov.companieshouse.service.TransactionService;
 import uk.gov.companieshouse.service.dissolution.DissolutionEmailService;
 import uk.gov.companieshouse.service.dissolution.chips.DissolutionChipsService;
 
@@ -30,6 +31,9 @@ class ResendEmailControllerTest {
 
     @MockitoBean
     private DissolutionChipsService service;
+
+    @MockitoBean
+    private TransactionService transactionService;
 
     @MockitoBean
     private DissolutionEmailService emailService;

--- a/src/test/java/uk/gov/companieshouse/controller/ResponseControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/ResponseControllerTest.java
@@ -12,6 +12,7 @@ import uk.gov.companieshouse.api.util.security.EricConstants;
 import uk.gov.companieshouse.api.util.security.SecurityConstants;
 import uk.gov.companieshouse.fixtures.ChipsFixtures;
 import uk.gov.companieshouse.model.dto.chips.ChipsResponseCreateRequest;
+import uk.gov.companieshouse.service.TransactionService;
 import uk.gov.companieshouse.service.dissolution.DissolutionService;
 import uk.gov.companieshouse.service.dissolution.chips.ChipsResponseService;
 
@@ -31,6 +32,9 @@ class ResponseControllerTest {
 
     @MockitoBean
     private ChipsResponseService chipsResponseService;
+
+    @MockitoBean
+    private TransactionService transactionService;
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/uk/gov/companieshouse/controller/SubmitControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/controller/SubmitControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.api.util.security.EricConstants;
 import uk.gov.companieshouse.api.util.security.SecurityConstants;
+import uk.gov.companieshouse.service.TransactionService;
 import uk.gov.companieshouse.service.dissolution.chips.DissolutionChipsService;
 
 import static org.mockito.Mockito.never;
@@ -25,6 +26,9 @@ class SubmitControllerTest {
 
     @MockitoBean
     private DissolutionChipsService service;
+
+    @MockitoBean
+    private TransactionService transactionService;
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/uk/gov/companieshouse/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/interceptor/TransactionInterceptorTest.java
@@ -1,0 +1,89 @@
+package uk.gov.companieshouse.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.HandlerMapping;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.exception.ServiceException;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.service.TransactionService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.companieshouse.model.Constants.TRANSACTION_ID_KEY;
+import static uk.gov.companieshouse.model.Constants.TRANSACTION_KEY;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionInterceptorTest {
+
+    private static final String TX_ID = "12345678";
+    private static final String PASSTHROUGH_HEADER = "passthrough";
+
+    @Mock
+    private TransactionService transactionService;
+
+    @Mock
+    private HttpServletRequest mockHttpServletRequest;
+
+    @Mock
+    private Logger logger;
+
+    @InjectMocks
+    private TransactionInterceptor transactionInterceptor;
+
+    @Test
+    void testPreHandleIsSuccessful() throws Exception {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        Object mockHandler = new Object();
+        Transaction dummyTransaction = new Transaction();
+        dummyTransaction.setId(TX_ID);
+
+        var pathParams = new HashMap<String, String>();
+        pathParams.put(TRANSACTION_ID_KEY, TX_ID);
+
+        when(transactionService.getTransaction(eq(TX_ID), eq(PASSTHROUGH_HEADER))).thenReturn(dummyTransaction);
+        when(mockHttpServletRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(pathParams);
+        when(mockHttpServletRequest.getHeader("ERIC-Access-Token")).thenReturn(PASSTHROUGH_HEADER);
+
+        assertTrue(transactionInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler));
+        verify(mockHttpServletRequest, times(1)).setAttribute(TRANSACTION_KEY, dummyTransaction);
+    }
+
+    @Test
+    void testPreHandleIsUnsuccessfulWhenServiceExceptionCaught() throws Exception {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        Object mockHandler = new Object();
+
+        var pathParams = new HashMap<String, String>();
+        pathParams.put(TRANSACTION_ID_KEY, TX_ID);
+
+        when(mockHttpServletRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(pathParams);
+        when(mockHttpServletRequest.getHeader("ERIC-Access-Token")).thenReturn(PASSTHROUGH_HEADER);
+        when(transactionService.getTransaction(eq(TX_ID), eq(PASSTHROUGH_HEADER))).thenThrow(ServiceException.class);
+
+        assertFalse(transactionInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler));
+        assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, mockHttpServletResponse.getStatus());
+    }
+
+    @Test
+    void testPreHandleIsUnsuccessfulWhenTransactionIdIsMissing() throws Exception {
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        Object mockHandler = new Object();
+
+        when(mockHttpServletRequest.getHeader("ERIC-Access-Token")).thenReturn(PASSTHROUGH_HEADER);
+        when(mockHttpServletRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(Map.of());
+
+        assertFalse(transactionInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler));
+        assertEquals(HttpServletResponse.SC_BAD_REQUEST, mockHttpServletResponse.getStatus());
+        verify(transactionService, never()).getTransaction(eq(TX_ID), eq(PASSTHROUGH_HEADER));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/interceptor/TransactionInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/interceptor/TransactionInterceptorTest.java
@@ -41,7 +41,7 @@ class TransactionInterceptorTest {
     private TransactionInterceptor transactionInterceptor;
 
     @Test
-    void testPreHandleIsSuccessful() throws Exception {
+    void interceptor_returnsTrue_ifTransactionExists() {
         MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
         Object mockHandler = new Object();
         Transaction dummyTransaction = new Transaction();
@@ -50,7 +50,7 @@ class TransactionInterceptorTest {
         var pathParams = new HashMap<String, String>();
         pathParams.put(TRANSACTION_ID_KEY, TX_ID);
 
-        when(transactionService.getTransaction(eq(TX_ID), eq(PASSTHROUGH_HEADER))).thenReturn(dummyTransaction);
+        when(transactionService.getTransaction(TX_ID, PASSTHROUGH_HEADER)).thenReturn(dummyTransaction);
         when(mockHttpServletRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(pathParams);
         when(mockHttpServletRequest.getHeader("ERIC-Access-Token")).thenReturn(PASSTHROUGH_HEADER);
 
@@ -59,7 +59,7 @@ class TransactionInterceptorTest {
     }
 
     @Test
-    void testPreHandleIsUnsuccessfulWhenServiceExceptionCaught() throws Exception {
+    void interceptor_returnsFalse_ifServiceExceptionOccurs() {
         MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
         Object mockHandler = new Object();
 
@@ -68,14 +68,14 @@ class TransactionInterceptorTest {
 
         when(mockHttpServletRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(pathParams);
         when(mockHttpServletRequest.getHeader("ERIC-Access-Token")).thenReturn(PASSTHROUGH_HEADER);
-        when(transactionService.getTransaction(eq(TX_ID), eq(PASSTHROUGH_HEADER))).thenThrow(ServiceException.class);
+        when(transactionService.getTransaction(TX_ID, PASSTHROUGH_HEADER)).thenThrow(ServiceException.class);
 
         assertFalse(transactionInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler));
         assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, mockHttpServletResponse.getStatus());
     }
 
     @Test
-    void testPreHandleIsUnsuccessfulWhenTransactionIdIsMissing() throws Exception {
+    void interceptor_throwsAnUnauthorisedError_ifTransactionIdIsMissing() {
         MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
         Object mockHandler = new Object();
 
@@ -84,6 +84,6 @@ class TransactionInterceptorTest {
 
         assertFalse(transactionInterceptor.preHandle(mockHttpServletRequest, mockHttpServletResponse, mockHandler));
         assertEquals(HttpServletResponse.SC_BAD_REQUEST, mockHttpServletResponse.getStatus());
-        verify(transactionService, never()).getTransaction(eq(TX_ID), eq(PASSTHROUGH_HEADER));
+        verify(transactionService, never()).getTransaction(TX_ID, PASSTHROUGH_HEADER);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/TransactionServiceTest.java
@@ -1,0 +1,84 @@
+package uk.gov.companieshouse.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.handler.transaction.TransactionsResourceHandler;
+import uk.gov.companieshouse.api.handler.transaction.request.TransactionsGet;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.api.sdk.ApiClientService;
+import uk.gov.companieshouse.exception.ServiceException;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionServiceTest {
+
+    private static final String TRANSACTION_ID = "12345678";
+    private static final String PASSTHROUGH_HEADER = "passthrough";
+    private static final String TRANSACTIONS_URL = "/transactions/";
+
+    @Mock
+    private ApiClientService apiClientService;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private TransactionsResourceHandler transactionsResourceHandler;
+
+    @Mock
+    private TransactionsGet transactionsGet;
+
+    @Mock
+    private ApiResponse<Transaction> apiGetResponse;
+
+    @InjectMocks
+    private TransactionService transactionService;
+
+    @Test
+    void testGettingATransactionIsSuccessful() throws IOException, URIValidationException {
+        Transaction transaction = new Transaction();
+        transaction.setId(TRANSACTION_ID);
+
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
+        when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
+        when(transactionsResourceHandler.get(TRANSACTIONS_URL + TRANSACTION_ID)).thenReturn(transactionsGet);
+        when(transactionsGet.execute()).thenReturn(apiGetResponse);
+        when(apiGetResponse.getData()).thenReturn(transaction);
+
+        var response = transactionService.getTransaction(TRANSACTION_ID, PASSTHROUGH_HEADER);
+
+        assertEquals(transaction, response);
+    }
+
+    @Test
+    void testServiceExceptionThrownWhenTransactionSdkThrowsURIValidationException() throws IOException, URIValidationException {
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
+        when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
+        when(transactionsResourceHandler.get(TRANSACTIONS_URL + TRANSACTION_ID)).thenReturn(transactionsGet);
+        when(transactionsGet.execute()).thenThrow(new URIValidationException("ERROR"));
+
+        assertThrows(ServiceException.class, () -> transactionService.getTransaction(TRANSACTION_ID, PASSTHROUGH_HEADER));
+    }
+
+    @Test
+    void testServiceExceptionThrownWhenTransactionSdkThrowsIOException() throws IOException, URIValidationException {
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
+        when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
+        when(transactionsResourceHandler.get(TRANSACTIONS_URL + TRANSACTION_ID)).thenReturn(transactionsGet);
+        when(transactionsGet.execute()).thenThrow(ApiErrorResponseException.fromIOException(new IOException("ERROR")));
+
+        assertThrows(ServiceException.class, () -> transactionService.getTransaction(TRANSACTION_ID, PASSTHROUGH_HEADER));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/service/TransactionServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/service/TransactionServiceTest.java
@@ -47,7 +47,7 @@ class TransactionServiceTest {
     private TransactionService transactionService;
 
     @Test
-    void testGettingATransactionIsSuccessful() throws IOException, URIValidationException {
+    void getTransaction_returnsTransactionData_ifTransactionExists() throws IOException, URIValidationException {
         Transaction transaction = new Transaction();
         transaction.setId(TRANSACTION_ID);
 
@@ -63,7 +63,7 @@ class TransactionServiceTest {
     }
 
     @Test
-    void testServiceExceptionThrownWhenTransactionSdkThrowsURIValidationException() throws IOException, URIValidationException {
+    void getTransaction_throwsServiceException_ifUriValidationExceptionOccurs() throws IOException, URIValidationException {
         when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
         when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
         when(transactionsResourceHandler.get(TRANSACTIONS_URL + TRANSACTION_ID)).thenReturn(transactionsGet);
@@ -73,7 +73,7 @@ class TransactionServiceTest {
     }
 
     @Test
-    void testServiceExceptionThrownWhenTransactionSdkThrowsIOException() throws IOException, URIValidationException {
+    void getTransaction_throwsServiceException_ifIOExceptionOccurs() throws IOException, URIValidationException {
         when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
         when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
         when(transactionsResourceHandler.get(TRANSACTIONS_URL + TRANSACTION_ID)).thenReturn(transactionsGet);


### PR DESCRIPTION
JIRA Ticket ID: [FS-394](https://companieshouse.atlassian.net/browse/FS-394)

## Context

When [migrating the dissolution-api to the transaction model](https://companieshouse.atlassian.net/wiki/spaces/ADG/pages/6486163509/2026-06-08+AAR+-+Migrate+Dissolution+to+the+Transaction+Model), we need expose endpoints that are queried by clients with a `transaction_id`.
These endpoints will then need to fetch the transaction data, in order to continue servicing the request.

> I used `confirmation-statement-api` and `overseas-entities-api` as inspiration

## Description

This PR sets up the boilerplate for interacting with the transactions API, so the new transaction model endpoints have the transaction data available when servicing a request.

**Summary of changes:**

- added the `TransactionService` to query a transaction by id, returning the transaction data
- added the `TransactionInterceptor` to parse the `transaction_id`, call the `TransactionService` to query the data, and pass the data as a **request attribute**.
    - registered the new interceptor, only allowing `/transactions/**` and `/private/transactions/**` paths
    - handled the error case when the `transaction_id` is not present
    - handled the error case when the transaction lookup fails

## Testing

The PR adds appropriate test coverage for the new service and interceptor.

> Note: I had to mock the `TransactionService` in the controllers  because `WebMvcTest` doesn't load `services` into the Spring Container / Application Context, so when it loads the `TransactionInterceptor`, it tries to find a bean for the `TransactionService` to inject into the `TransactionInterceptor`, this needs to be mocked.

## FAQ
 
> Will this affect existing API endpoints?

It shouldn't, you provide an allow list of paths when registering the interceptor, existing `dissolution-api` endpoints do not have the term `transactions` in their path.

> Does this need a feature flag?

No, it requires the client having knowledge of the new paths, and to provide a transaction id, potentially we could add some rate limiting, but i think eric already does this?


[FS-394]: https://companieshouse.atlassian.net/browse/FS-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ